### PR TITLE
Use Module.split instead of inspect |> String.split(".")

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -62,10 +62,7 @@ defmodule NewRelixir.Plug.Instrumentation do
   end
 
   defp model_name(model_type) do
-    model_type
-    |> inspect
-    |> String.split(".")
-    |> List.last
+    model_type |> Module.split |> List.last
   end
 
   defp record(opts, elapsed) do

--- a/lib/new_relixir/plug/phoenix.ex
+++ b/lib/new_relixir/plug/phoenix.ex
@@ -27,7 +27,7 @@ defmodule NewRelixir.Plug.Phoenix do
 
   def call(conn, _config) do
     if NewRelixir.configured? do
-      module = conn |> controller_module |> inspect |> String.split(".") |> List.last
+      module = conn |> controller_module |> Module.split |> List.last
       action = conn |> action_name |> Atom.to_string
       transaction_name = "/#{module}##{action}"
 


### PR DESCRIPTION
Hi, thank you for opensourcing this project.

I read the code and found a few calls of `inspect` to get module name. I guess, it is not the best choice, so I propose to use `Module` module to work with such the things.
And I'm wondering why you get only last part of module name in both cases?
