### PR TITLE
Use all fragments of module name except the first one instead of only last one.

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -62,7 +62,7 @@ defmodule NewRelixir.Plug.Instrumentation do
   end
 
   defp model_name(model_type) do
-    model_type |> Module.split |> List.last
+    model_type |> Module.split |> tl |> Enum.join(".")
   end
 
   defp record(opts, elapsed) do

--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -2,6 +2,7 @@ defmodule NewRelixir.Plug.Instrumentation do
   @moduledoc """
   Utility methods for instrumenting parts of an Elixir app.
   """
+  import NewRelixir.Utils
 
   @doc """
   Instruments a database call and records the elapsed time.
@@ -42,7 +43,7 @@ defmodule NewRelixir.Plug.Instrumentation do
   end
 
   defp infer_model(%{__struct__: model_type, __meta__: %Ecto.Schema.Metadata{}}) do
-    model_name(model_type)
+    short_module_name(model_type)
   end
 
   defp infer_model(%Ecto.Changeset{model: model}) do
@@ -50,7 +51,7 @@ defmodule NewRelixir.Plug.Instrumentation do
   end
 
   defp infer_model(%Ecto.Query{from: {_, model_type}}) do
-    model_name(model_type)
+    short_module_name(model_type)
   end
 
   defp infer_model(%Ecto.Query{}) do
@@ -59,10 +60,6 @@ defmodule NewRelixir.Plug.Instrumentation do
 
   defp infer_model(queryable) do
     infer_model(Ecto.Queryable.to_query(queryable))
-  end
-
-  defp model_name(model_type) do
-    model_type |> Module.split |> tl |> Enum.join(".")
   end
 
   defp record(opts, elapsed) do

--- a/lib/new_relixir/plug/phoenix.ex
+++ b/lib/new_relixir/plug/phoenix.ex
@@ -27,7 +27,7 @@ defmodule NewRelixir.Plug.Phoenix do
 
   def call(conn, _config) do
     if NewRelixir.configured? do
-      module = conn |> controller_module |> Module.split |> List.last
+      module = conn |> controller_module |> Module.split |> tl |> Enum.join(".")
       action = conn |> action_name |> Atom.to_string
       transaction_name = "/#{module}##{action}"
 

--- a/lib/new_relixir/plug/phoenix.ex
+++ b/lib/new_relixir/plug/phoenix.ex
@@ -20,6 +20,7 @@ defmodule NewRelixir.Plug.Phoenix do
   @behaviour Elixir.Plug
   import Elixir.Phoenix.Controller
   import Elixir.Plug.Conn
+  import NewRelixir.Utils
 
   def init(opts) do
     opts
@@ -27,7 +28,7 @@ defmodule NewRelixir.Plug.Phoenix do
 
   def call(conn, _config) do
     if NewRelixir.configured? do
-      module = conn |> controller_module |> Module.split |> tl |> Enum.join(".")
+      module = conn |> controller_module |> short_module_name
       action = conn |> action_name |> Atom.to_string
       transaction_name = "/#{module}##{action}"
 

--- a/lib/new_relixir/utils.ex
+++ b/lib/new_relixir/utils.ex
@@ -1,0 +1,8 @@
+defmodule NewRelixir.Utils do
+  def short_module_name(module) do
+    module |> Module.split |> join_without_prefix
+  end
+
+  defp join_without_prefix([module_name]), do: module_name
+  defp join_without_prefix([_|name_parts]), do: Enum.join(name_parts, ".")
+end

--- a/test/new_relixir/plug/instrumentation_test.exs
+++ b/test/new_relixir/plug/instrumentation_test.exs
@@ -6,12 +6,6 @@ defmodule NewRelixir.Plug.InstrumentationTest do
 
   alias NewRelixir.Plug.Instrumentation
 
-  defmodule FakeModel do
-    use Ecto.Schema
-    schema "fake_models" do
-    end
-  end
-
   @transaction_name "TestTransaction"
 
   setup do

--- a/test/new_relixir/plug/repo_test.exs
+++ b/test/new_relixir/plug/repo_test.exs
@@ -121,12 +121,6 @@ defmodule NewRelixir.Plug.RepoTest do
     end
   end
 
-  defmodule FakeModel do
-    use Ecto.Schema
-    schema "fake_models" do
-    end
-  end
-
   import TestHelpers.Assertions
   import Plug.Conn
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,4 +14,10 @@ defmodule TestHelpers.Assertions do
   end
 end
 
+defmodule FakeModel do
+  use Ecto.Schema
+  schema "fake_models" do
+  end
+end
+
 ExUnit.start()


### PR DESCRIPTION
As proposed in #4 
