### PR TITLE
Fix dependencies to be able to build release with exrm

### DIFF
--- a/lib/new_relixir.ex
+++ b/lib/new_relixir.ex
@@ -13,7 +13,6 @@ defmodule NewRelixir do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(:statman_server, [1000]),
       worker(:statman_aggregator, []),
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule NewRelixir.Mixfile do
 
   def application do
     [mod: {NewRelixir, []},
-     applications: [:logger, :lhttpc]]
+     applications: [:logger, :lhttpc, :newrelic]]
   end
 
   defp deps do


### PR DESCRIPTION
When I was trying to deploy my app with edeliver, no data was sent to NewRelic.
After some research I found out that `newrelic` app was not built to the release package, b/c it isn't listed in applications. But you can not just add it to applications, b/c it starts `statman_server` as well and it leads to `already started` errors.
See possible solution in the commit.
