### PR TITLE
Upgrade phoenix to 1.2, upgrade Ecto to 2.0

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -45,8 +45,8 @@ defmodule NewRelixir.Plug.Instrumentation do
     model_name(model_type)
   end
 
-  defp infer_model(%Ecto.Changeset{model: model}) do
-    infer_model(model)
+  defp infer_model(%Ecto.Changeset{data: %{__struct__: model_type}}) do
+    model_name(model_type)
   end
 
   defp infer_model(%Ecto.Query{from: {_, model_type}}) do

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,8 @@ defmodule NewRelixir.Mixfile do
   end
 
   defp deps do
-    [{:phoenix, "~> 1.1"},
-     {:ecto, "~> 1.1"},
+    [{:phoenix, "~> 1.2"},
+     {:ecto, "~> 2.0"},
      {:newrelic, "~> 0.1.0"},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.11", only: :dev}]

--- a/test/new_relixir/plug/instrumentation_test.exs
+++ b/test/new_relixir/plug/instrumentation_test.exs
@@ -41,7 +41,7 @@ defmodule NewRelixir.Plug.InstrumentationTest do
   end
 
   test "instrument_db infers query name from Ecto changeset and action name", %{conn: conn} do
-    changeset = Ecto.Changeset.cast(%FakeModel{}, %{}, [], [])
+    changeset = Ecto.Changeset.change(%FakeModel{}, %{})
     Instrumentation.instrument_db(:foo, changeset, [conn: conn], fn -> nil end)
     assert_contains(:statman_histogram.keys, {@transaction_name, {:db, "FakeModel.foo"}})
   end


### PR DESCRIPTION
Upgrade phoenix to 1.2, upgrade Ecto to 2.0

There are some breaking changes to the Ecto public interface. We need to slightly modify our instrumentation plug
