### PR TITLE
Add aggregate/4 to Plug.Repo

### DIFF
--- a/lib/new_relixir/plug/repo.ex
+++ b/lib/new_relixir/plug/repo.ex
@@ -155,6 +155,13 @@ defmodule NewRelixir.Plug.Repo do
         end)
       end
 
+      @spec aggregate(Ecto.Queryable.t, :avg | :count | :max | :min | :sum, atom, Keyword.t) :: term | nil
+      def aggregate(queryable, aggregate, field, opts \\ []) do
+        instrument_db(:aggregate, queryable, opts, fn() ->
+          repo().aggregate(queryable, aggregate, field, opts)
+        end)
+      end
+
       @spec preload([Ecto.Schema.t] | Ecto.Schema.t, preloads :: term) :: [Ecto.Schema.t] | Ecto.Schema.t
       def preload(model_or_models, preloads, opts \\ []) do
         instrument_db(:preload, model_or_models, opts, fn() ->


### PR DESCRIPTION
Closes #21 by adding `aggregate/4` to lib/new-relixir/plug/repo.ex.

Pretty much done by copy-pasting other functions / tests and adjusting them to match [the arguments expected by Ecto.Repo.aggregate/4](https://hexdocs.pm/ecto/Ecto.Repo.html#c:aggregate/4). The `@spec` was derived from [the relevant `@callback` attribute in Ecto's source](https://github.com/elixir-ecto/ecto/blob/v2.1.4/lib/ecto/repo.ex#L376).