### PR TITLE
Reduce logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Phoenix application named `MyApp`.
       end
 
       defp deps do
-        [{:new_relixir, "~> 0.1.0"}]
+        [{:new_relixir, "~> 0.4.0"}]
       end
     end
     ```

--- a/lib/new_relixir/agent.ex
+++ b/lib/new_relixir/agent.ex
@@ -8,7 +8,7 @@ defmodule NewRelixir.Agent do
   formatted data and registers it under the given hostname.
   """
   def push(hostname, data, errors) do
-    if NewRelixir.configured? do
+    if NewRelixir.active? do
       collector = get_redirect_host()
       run_id = connect(collector, hostname)
       case push_metric_data(collector, run_id, data) do

--- a/lib/new_relixir/plug/phoenix.ex
+++ b/lib/new_relixir/plug/phoenix.ex
@@ -27,7 +27,7 @@ defmodule NewRelixir.Plug.Phoenix do
   end
 
   def call(conn, _config) do
-    if NewRelixir.configured? do
+    if NewRelixir.active? do
       module = conn |> controller_module |> short_module_name
       action = conn |> action_name |> Atom.to_string
       transaction_name = "#{module}##{action}"

--- a/lib/new_relixir/polling.ex
+++ b/lib/new_relixir/polling.ex
@@ -32,7 +32,6 @@ defmodule NewRelixir.Polling do
     try do
       case pull_fun.() do
         {[], [], _internval} ->
-          Logger.debug "Nothing to send."
           :ok
         {metrics, errors, {start_time, end_time}} ->
           metrics = [

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule NewRelixir.Mixfile do
   def project do
     [app: :new_relixir,
      name: "New Relixir",
-     version: "0.4.0-rc.0",
+     version: "0.4.0",
      elixir: "~> 1.5",
      description: "New Relic tracking for Elixir applications.",
      package: package(),

--- a/test/new_relixir/plug/phoenix_test.exs
+++ b/test/new_relixir/plug/phoenix_test.exs
@@ -7,13 +7,9 @@ defmodule NewRelixir.Plug.PhoenixTest do
   @moduletag configured: true
 
   setup %{configured: configured} do
-    if configured do
-      Application.put_env(:new_relixir, :application_name, to_charlist("App Name"))
-      Application.put_env(:new_relixir, :license_key, to_charlist("License Key"))
-    else
-      Application.delete_env(:new_relixir, :application_name)
-      Application.delete_env(:new_relixir, :license_key)
-    end
+    previous_setting = Application.get_env(:new_relixir, :active)
+    Application.put_env(:new_relixir, :active, configured)
+    on_exit fn -> Application.put_env(:new_relixir, :active, previous_setting) end
 
     conn = %Plug.Conn{}
     |> put_private(:phoenix_controller, SomeApplication.FakeController)


### PR DESCRIPTION
We still want to collect and process metrics in `test` and `dev` environments, without reporting to New Relic.