### PR TITLE
Phoenix Instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Version 0.4.0
 
+*  Support Phoenix built-in instrumentation [#31](https://github.com/TheRealReal/new-relixir/pull/31)
+*  Support for Plug-only, non-Phoenix applications [#31](https://github.com/TheRealReal/new-relixir/pull/31)
+*  Deprecate `NewRelixir.Plug.Phoenix` [#31](https://github.com/TheRealReal/new-relixir/pull/31)
 *  Remove statman and newrelic dependencies ( replace with Agent ) [#24](https://github.com/TheRealReal/new-relixir/pull/24)
 *  Replace lhttpc with hackney [#24](https://github.com/TheRealReal/new-relixir/pull/24)
 *  Support Repo.aggregate/4 instrumentation [#22](https://github.com/TheRealReal/new-relixir/commit/dc178ef3c84671b5c06b204b912f9c82968ab33c)
-*  support insert_all/3 [#32](https://github.com/TheRealReal/new-relixir/pull/32)
-*  fix preload with multiple structs by inferring name from first entry [#33](https://github.com/TheRealReal/new-relixir/pull/33)
+*  Support insert_all/3 [#32](https://github.com/TheRealReal/new-relixir/pull/32)
+*  Fix preload with multiple structs by inferring name from first entry [#33](https://github.com/TheRealReal/new-relixir/pull/33)
 *  Update Ecto dependency to ~> 2.0
 *  Update Elixir dependency to ~> 1.5
 *  Update Phoenix dependency to ~> 1.3

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # New Relixir
 
-Instrument your Phoenix applications with New Relic.
+Instrument your Phoenix and Plug applications with New Relic.
 
-New Relixir currently supports instrumenting Phoenix controllers and Ecto repositories to record
-response times for web transactions and database queries.
+New Relixir currently supports instrumenting bare-bones Plug endpoints, Phoenix
+controllers and Ecto repositories, to record response times of web transactions
+and database queries.
 
 * [Documentation](https://hexdocs.pm/new_relixir/)
 
@@ -44,8 +45,19 @@ Phoenix application named `MyApp`.
       license_key: System.get_env("NEWRELIC_LICENSE_KEY")
     ```
 
+3.  Add `NewRelixir.Instrumenters.Phoenix` to the list of instrumenters in your `Endpoint`
+    configuration:
 
-3.  Define a module to wrap your repository's methods with New Relic instrumentation:
+    ```elixir
+    # config/config.exs
+
+    config :my_app, MyAppWeb.Endpoint,
+      instrumenters: [NewRelixir.Instrumenters.Phoenix],
+      # ...
+    ```
+
+4.  If your app also uses `Ecto`, define a module to wrap your repository's methods with
+    New Relic instrumentation:
 
     ```elixir
     # lib/my_app/repo.ex
@@ -59,30 +71,48 @@ Phoenix application named `MyApp`.
     end
     ```
 
-    Now `MyApp.Repo.NewRelic` can be used as a substitute for `MyApp.Repo`. If a `Plug.Conn` is
-    provided as the `:conn` option to any of the wrapper's methods, it will instrument the response
-    time for that call. Otherwise, the repository will behave the same as the repository that it
-    wraps.
+    Now `MyApp.Repo.NewRelic` can be used as a substitute for `MyApp.Repo`. It will dispatch
+    and instrument the response time for all `Repo` calls.
 
-4.  For any Phoenix controller that you want to instrument, add `NewRelixir.Plug.Phoenix` and
-    replace existing aliases to your application's repository with an alias to your New Relic
-    repository wrapper. If instrumenting all controllers, update `web/web.ex`:
+    If you've defined custom functions on your `Repo`, you will need to define them on your
+    wrapper module as well. In the wrapper module, simply call your repository's original
+    function inside a closure that you pass to `instrument_db`:
 
     ```elixir
-    # web/web.ex
+    # lib/my_app/repo.ex
 
-    defmodule MyApp.Web do
-      def controller do
-        quote do
-          # ...
-          plug NewRelixir.Plug.Phoenix
-          alias MyApp.Repo.NewRelic, as: Repo # Replaces `alias MyApp.Repo`
+    defmodule MyApp.Repo do
+      use Ecto.Repo, otp_app: :my_app
+
+      def my_custom_operation(queryable, opts \\ []) do
+        # ...
+      end
+
+      defmodule NewRelic do
+        use NewRelixir.Plug.Repo, repo: MyApp.Repo
+
+        def my_custom_operation(queryable, opts \\ []) do
+          instrument_db(:my_custom_operation, queryable, opts, fn() ->
+            MyApp.Repo.my_custom_operation(queryable, opts)
+          end)
         end
       end
     end
     ```
 
-5.  Update your controllers to pass `conn` as an option to your New Relic repo wrapper:
+    When using the wrapper module's `my_custom_operation`, the time it takes to call
+    `MyApp.Repo.my_custom_operation/2` will be recorded to New Relic.
+
+## Upgrading from 0.3.x
+
+1.  Remove `NewRelixir.Plug.Phoenix` from your Plug pipeline and all further references to
+    that module.
+
+2.  Add `NewRelixir.Instrumenters.Phoenix` to the list of instrumenters in your `Endpoint`
+    configuration. See more in [usage](#usage).
+
+3.  Passing a `conn` to the functions of your `Repo` wrapper is no longer required, calls
+    to the wrapper can now be made the same way as calls to the original `Repo`:
 
     ```elixir
     # web/controllers/users.ex
@@ -91,42 +121,14 @@ Phoenix application named `MyApp`.
       use MyApp.Web, :controller
 
       def index(conn, _params) do
-        users = Repo.all(User, conn: conn) # Replaces `Repo.all(User)`
-        # ...
+        # Before
+        users = Repo.all(User, conn: conn)
+
+        # Now
+        users = Repo.all(User)
       end
     end
     ```
-
-### Instrumenting Custom Repo Methods
-
-If you've defined custom methods on your repository, you will need to define them on your wrapper
-module as well. In the wrapper module, simply call your repository's original method inside a
-closure that you pass to `instrument_db`:
-
-```elixir
-# lib/my_app/repo.ex
-
-defmodule MyApp.Repo do
-  use Ecto.Repo, otp_app: :my_app
-
-  def custom_method(queryable, opts \\ []) do
-    # ...
-  end
-
-  defmodule NewRelic do
-    use NewRelixir.Plug.Repo, repo: MyApp.Repo
-
-    def custom_method(queryable, opts \\ []) do
-      instrument_db(:custom_method, queryable, opts, fn() ->
-        MyApp.Repo.custom_method(queryable, opts)
-      end)
-    end
-  end
-end
-```
-
-When using the wrapper module's `custom_method`, the time it takes to call
-`MyApp.Repo.custom_method/2` will be recorded to New Relic.
 
 ## Copyright
 

--- a/lib/new_relixir/current_transaction.ex
+++ b/lib/new_relixir/current_transaction.ex
@@ -1,0 +1,54 @@
+defmodule NewRelixir.CurrentTransaction do
+  @moduledoc """
+  Keeps track of the New Relic transaction name for the current process.
+
+  As soon as a request starts and its transaction name is determined, that
+  name is stored in the process dictionary with `CurrentTransaction.get`.
+
+  Later on, spawned descendent processes can still record custom calls and
+  database operations under the same parent New Relic transaction.
+  """
+  @key :new_relixir_transaction
+
+  @doc """
+  Lookup through process ancestors and find the NewRelic transaction.
+
+  This function permits you trigger async tasks in controller actions and
+  still inform the external request time in the same context.
+  """
+  @spec get() :: {:ok, binary} | {:error, :not_found}
+  def get do
+    if transaction = Process.get(@key) || search_on_ancestors() do
+      {:ok, transaction}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Associate the given transaction with the current process.
+  """
+  @spec set(transaction :: term) :: binary | nil
+  def set(transaction) when is_binary(transaction) do
+    Process.put(@key, transaction)
+    transaction
+  end
+  def set(_), do: nil
+
+  # Getting the other processes info generate locks. That's why this
+  # function puts NewRelic transaction in the current process dictionary,
+  # to avoid lock in future external requests in this same process.
+  defp search_on_ancestors do
+    :"$ancestors"
+    |> Process.get([])
+    |> Enum.find_value(&extract_transaction/1)
+    |> set
+  end
+
+  defp extract_transaction(pid) do
+    case Process.info(pid, :dictionary) do
+      {:dictionary, info} -> info[@key]
+      _ -> nil
+    end
+  end
+end

--- a/lib/new_relixir/instrumenters/phoenix.ex
+++ b/lib/new_relixir/instrumenters/phoenix.ex
@@ -1,0 +1,25 @@
+defmodule NewRelixir.Instrumenters.Phoenix do
+  @moduledoc """
+  New Relic instrumenter for Phoenix controllers.
+
+  It relies on the instrumentation API provided by `Phoenix.Endpoint`. To set it up,
+  include this module in the list of `instrumenters` of your Endpoint config:
+
+      config :my_app, MyAppWeb.Endpoint,
+        instrumenters: [NewRelixir.Instrumenters.Phoenix],
+
+  """
+  alias NewRelixir.Utils
+
+  def phoenix_controller_call(:start, _compile_metadata, %{conn: conn}) do
+    if NewRelixir.active?, do: Utils.transaction_name(conn)
+  end
+
+  def phoenix_controller_call(:stop, elapsed_time, transaction_name) do
+    if NewRelixir.active? do
+      elapsed_microseconds = System.convert_time_unit(elapsed_time, :native, :microsecond)
+
+      NewRelixir.Collector.record_value({transaction_name, :total}, elapsed_microseconds)
+    end
+  end
+end

--- a/lib/new_relixir/instrumenters/phoenix.ex
+++ b/lib/new_relixir/instrumenters/phoenix.ex
@@ -11,8 +11,16 @@ defmodule NewRelixir.Instrumenters.Phoenix do
   Transaction traces will be composed of both controller and action names, e.g.
   `/HomeController#index`, `/ProfileController#update`.
   """
+
   alias NewRelixir.{CurrentTransaction, Transaction, Utils}
 
+  @doc """
+  Start callback for Phoenix controllers. Phoenix calls it once a request is routed,
+  before processing a controller action.
+
+  Returns the transaction name, formatted as `Controller#action`. This value is
+  stored and passed along as the third argument to the `:stop` callback.
+  """
   def phoenix_controller_call(:start, _compile_metadata, %{conn: conn}) do
     if NewRelixir.active? do
       transaction = Utils.transaction_name(conn)
@@ -21,6 +29,10 @@ defmodule NewRelixir.Instrumenters.Phoenix do
     end
   end
 
+  @doc """
+  Stop callback for Phoenix controllers. Phonix calls it after the whole controller
+  pipeline finishes executing the routed action.
+  """
   def phoenix_controller_call(:stop, elapsed_time, transaction) do
     if NewRelixir.active? do
       elapsed_microseconds = System.convert_time_unit(elapsed_time, :native, :microsecond)

--- a/lib/new_relixir/instrumenters/phoenix.ex
+++ b/lib/new_relixir/instrumenters/phoenix.ex
@@ -8,6 +8,8 @@ defmodule NewRelixir.Instrumenters.Phoenix do
       config :my_app, MyAppWeb.Endpoint,
         instrumenters: [NewRelixir.Instrumenters.Phoenix],
 
+  Transaction traces will be composed of both controller and action names, e.g.
+  `/HomeController#index`, `/ProfileController#update`.
   """
   alias NewRelixir.Utils
 

--- a/lib/new_relixir/instrumenters/plug.ex
+++ b/lib/new_relixir/instrumenters/plug.ex
@@ -1,0 +1,61 @@
+defmodule NewRelixir.Instrumenters.Plug do
+  @moduledoc """
+  New Relic instrumenter for raw Plug endpoints.
+
+  Transaction records are composed of the current request path and method, e.g.
+  `/path/to/my-page#GET`, `/path/to/update#POST`.
+
+  To start recording, add `plug NewRelixir.Instrumenters.Plug` at the beginning of
+  your pipeline:
+
+  ```
+  defmodule MyApp.PlugRouter do
+    use Plug.Router
+
+    plug NewRelixir.Instrumenters.Plug
+
+    plug :match
+    plug :dispatch
+
+    get "/hello" do
+      send_resp(conn, 200, "Hello!")
+    end
+  end
+  ```
+  """
+
+  @behaviour Elixir.Plug
+
+  alias Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _config) do
+    if NewRelixir.active? do
+      record_transaction(conn)
+    else
+      conn
+    end
+  end
+
+  defp record_transaction(conn) do
+    transaction = start_transaction(conn)
+
+    conn
+    |> Conn.put_private(:new_relixir_transaction, transaction)
+    |> Conn.register_before_send(&finish_transaction/1)
+  end
+
+  defp start_transaction(%Conn{request_path: "/" <> path, method: method}) do
+    transaction_name = "#{path}##{method}"
+    NewRelixir.Transaction.start(transaction_name)
+  end
+
+  defp finish_transaction(conn) do
+    transaction = Map.get(conn.private, :new_relixir_transaction)
+
+    NewRelixir.Transaction.finish(transaction)
+
+    conn
+  end
+end

--- a/lib/new_relixir/instrumenters/plug.ex
+++ b/lib/new_relixir/instrumenters/plug.ex
@@ -2,11 +2,8 @@ defmodule NewRelixir.Instrumenters.Plug do
   @moduledoc """
   New Relic instrumenter for raw Plug endpoints.
 
-  Transaction records are composed of the current request path and method, e.g.
-  `/path/to/my-page#GET`, `/path/to/update#POST`.
-
-  To start recording, add `plug NewRelixir.Instrumenters.Plug` at the beginning of
-  your pipeline:
+  To start recording, attach `plug NewRelixir.Instrumenters.Plug` at the
+  beginning of your pipeline:
 
   ```
   defmodule MyApp.PlugRouter do
@@ -22,6 +19,9 @@ defmodule NewRelixir.Instrumenters.Plug do
     end
   end
   ```
+
+  Transaction records are composed of the current request path and method, e.g.
+  `/path/to/my-page#GET`, `/path/to/update#POST`.
   """
 
   @behaviour Plug

--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -10,12 +10,13 @@ defmodule NewRelixir.Plug.Instrumentation do
   @doc """
   Instruments a database call and records the elapsed time.
 
-  * `action` is the name of the repository method being instrumented.
+  * `action` is the name of the repository function being instrumented.
   * `queryable` is the `Queryable` being passed to the repository.
+  * `opts` is a keyword list of overrides to parts of the recorded transaction name.
   * `f` is the function to be instrumented.
 
-  By default, the query name will be infered from `queryable` and `action`. This can be overriden
-  by providing a `:query` option in `opts`.
+  By default, the query name will be inferred from `queryable` and `action`. This
+  can be overriden by providing a `:query` option in `opts`.
   """
   @spec instrument_db(atom, Ecto.Queryable.t, Keyword.t, fun) :: any
   def instrument_db(action, queryable, opts, f) do

--- a/lib/new_relixir/plug/phoenix.ex
+++ b/lib/new_relixir/plug/phoenix.ex
@@ -1,5 +1,7 @@
 defmodule NewRelixir.Plug.Phoenix do
   @moduledoc """
+  WARNING: this module is deprecated.
+
   A plug that instruments Phoenix controllers and records their response times in New Relic.
 
   Inside an instrumented controller's actions, `conn` can be used for further instrumentation with
@@ -22,7 +24,14 @@ defmodule NewRelixir.Plug.Phoenix do
   alias NewRelixir.Utils
   alias Plug.Conn
 
-  def init(opts), do: opts
+  def init(opts) do
+    IO.warn """
+      `NewRelixir.Plug.Phoenix` is deprecated; use `NewRelixir.Instrumenters.Phoenix`
+      instead. For Plug-based non-Phoenix projects, use `NewRelixir.Instrumenters.Plug`.
+    """, []
+
+    opts
+  end
 
   def call(conn, _config) do
     if NewRelixir.active? do

--- a/lib/new_relixir/plug/phoenix.ex
+++ b/lib/new_relixir/plug/phoenix.ex
@@ -4,16 +4,22 @@ defmodule NewRelixir.Plug.Phoenix do
 
   A plug that instruments Phoenix controllers and records their response times in New Relic.
 
-  Inside an instrumented controller's actions, `conn` can be used for further instrumentation with
-  `NewRelixir.Plug.Instrumentation` and `NewRelixir.Plug.Repo`.
+  Inside an instrumented controller's actions, instrumented `Repo` calls will be scoped
+  under the current web transaction.
 
   ```
-  defmodule MyApp.UsersController do
+  defmodule MyApp.UserController do
     use Phoenix.Controller
+
     plug NewRelixir.Plug.Phoenix
 
+    alias MyApp.Repo.NewRelic, as: Repo
+
     def index(conn, _params) do
-      # `conn` is setup for instrumentation
+      users = Repo.all(User)
+      # This database call is recorded as `Repo.all` under `UserController#index`.
+
+      render(conn, "index.html", users: users)
     end
   end
   ```

--- a/lib/new_relixir/plug/repo.ex
+++ b/lib/new_relixir/plug/repo.ex
@@ -12,11 +12,11 @@ defmodule NewRelixir.Plug.Repo do
   end
   ```
 
-  Anywhere that the original repository is used to make a database call, the wrapper module can be
-  used by adding a `Plug.Conn` as the first argument. For example, `MyApp.Repo.all(User)` can be
-  replaced with `MyApp.Repo.NewRelic.all(conn, User)`. No changes are needed for `transaction()`
-  and `rollback()`. The `Plug.Conn` that's used with query methods must be one that was setup by
-  `NewRelixir.Plug.Phoenix`.
+  Anywhere that the original repository is used to make a database call, the
+  wrapper module can be used instead. For example, `MyApp.Repo.all(User)` can
+  be replaced with `MyApp.Repo.NewRelic.all(User)`. These database calls must
+  be done in the scope of an instrumented Phoenix controller or Plug endpoint.
+  Calls made from spawned child subprocesses are supported.
   """
 
   defmacro __using__(opts) do

--- a/lib/new_relixir/transaction.ex
+++ b/lib/new_relixir/transaction.ex
@@ -3,67 +3,37 @@ defmodule NewRelixir.Transaction do
   Records information about an instrumented web transaction.
   """
 
-  defstruct [:name, :start_time]
-
-  @typedoc "A New Relixir transaction context."
-  @opaque t :: %__MODULE__{name: String.t, start_time: :erlang.timestamp}
-
-  @typedoc "The name of a model."
-  @type model :: String.t
-
-  @typedoc "The name of a repository action."
-  @type action :: atom
-
-  @typedoc "The name of a query."
-  @type query :: String.t | {model, action}
-
-  @typedoc "Elapsed time in microseconds."
-  @type interval :: non_neg_integer
+  alias NewRelixir.Collector
 
   @doc """
-  Creates a new web transaction.
-
-  This method should be called just before processing a web transaction.
+  Records the total time of a web transaction.
   """
-  @spec start(String.t) :: t
-  def start(name) when is_binary(name) do
-    %__MODULE__{name: name, start_time: :os.timestamp}
+  @spec record_web(transaction :: binary, elapsed_time :: integer) :: :ok
+  def record_web(transaction, elapsed_time)
+      when is_binary(transaction)
+      and is_integer(elapsed_time) do
+    Collector.record_value({transaction, :total}, elapsed_time)
   end
 
   @doc """
-  Finishes a web transaction.
-
-  This method should be called just after processing a web transaction. It will record the elapsed
-  time of the transaction.
+  Records a database query made in a web transaction.
   """
-  @spec finish(t) :: :ok
-  def finish(%__MODULE__{start_time: start_time} = transaction) do
-    end_time = :os.timestamp
-    elapsed = :timer.now_diff(end_time, start_time)
-
-    record_value!(transaction, :total, elapsed)
+  @spec record_db(transaction :: binary, query :: binary, elapsed_time :: integer) :: :ok
+  def record_db(transaction, query, elapsed_time)
+      when is_binary(transaction)
+      and is_binary(query)
+      and is_integer(elapsed_time) do
+    Collector.record_value({transaction, {:db, query}}, elapsed_time)
   end
 
   @doc """
-  Records a database query for the current web transaction.
-
-  The query name can either be provided as a raw string or as a tuple containing a model and action
-  name.
+  Records an external HTTP call made in a web transaction.
   """
-  @spec record_db(t, query, interval) :: :ok
-  def record_db(%__MODULE__{} = transaction, {model, action}, elapsed) do
-    record_db(transaction, "#{model}.#{action}", elapsed)
-  end
-
-  def record_db(%__MODULE__{} = transaction, query, elapsed) when is_binary(query) do
-    record_value!(transaction, {:db, query}, elapsed)
-  end
-
-  def record_external(%__MODULE__{} = transaction, host, elapsed) do
-    record_value!(transaction, {:ext, host}, elapsed)
-  end
-
-  defp record_value!(%__MODULE__{name: name}, data, elapsed) do
-    :ok = NewRelixir.Collector.record_value({name, data}, elapsed)
+  @spec record_external(transaction :: binary, host :: binary, elapsed_time :: integer) :: :ok
+  def record_external(transaction, host, elapsed_time)
+      when is_binary(transaction)
+      and is_binary(host)
+      and is_integer(elapsed_time) do
+    Collector.record_value({transaction, {:ext, host}}, elapsed_time)
   end
 end

--- a/lib/new_relixir/utils.ex
+++ b/lib/new_relixir/utils.ex
@@ -1,4 +1,12 @@
 defmodule NewRelixir.Utils do
+  import Phoenix.Controller, only: [controller_module: 1, action_name: 1]
+
+  def transaction_name(conn) do
+    module = conn |> controller_module |> short_module_name
+    action = conn |> action_name
+    "#{module}##{action}"
+  end
+
   def short_module_name(module) do
     module |> Module.split |> join_without_prefix
   end

--- a/test/new_relixir/current_transaction_test.exs
+++ b/test/new_relixir/current_transaction_test.exs
@@ -1,0 +1,46 @@
+defmodule NewRelixir.CurrentTransactionTest do
+  use ExUnit.Case, async: true
+
+  alias NewRelixir.CurrentTransaction
+
+  describe "get/0" do
+    test "gets existing transaction from the current process" do
+      Process.put(:new_relixir_transaction, "the-transaction")
+
+      assert {:ok, "the-transaction"} == CurrentTransaction.get()
+    end
+
+    test "gets transaction from grandparent process and sets on current when missing" do
+      Process.put(:new_relixir_transaction, "ancestor-transaction")
+
+      parent = Task.async fn ->
+        child = Task.async(&CurrentTransaction.get/0)
+        Task.await(child)
+      end
+
+      {:ok, transaction} = Task.await(parent)
+
+      assert "ancestor-transaction" == transaction
+    end
+
+    test "returns error when missing from the current process dictionary and from ancestors" do
+      assert {:error, :not_found} == CurrentTransaction.get()
+    end
+  end
+
+  describe "set/1" do
+    test "stores the given transaction in the process dictionary" do
+      transaction = CurrentTransaction.set("the-transaction")
+
+      assert "the-transaction" == transaction
+      assert "the-transaction" == Process.get(:new_relixir_transaction)
+    end
+
+    test "does nothing with nil" do
+      transaction = CurrentTransaction.set(nil)
+
+      assert nil == transaction
+      assert nil == Process.get(:new_relixir_transaction)
+    end
+  end
+end

--- a/test/new_relixir/instrumenters/phoenix_test.exs
+++ b/test/new_relixir/instrumenters/phoenix_test.exs
@@ -1,0 +1,47 @@
+defmodule NewRelixir.Instrumenters.PhoenixTest do
+  use ExUnit.Case
+
+  import TestHelpers.Assertions
+
+  alias NewRelixir.CurrentTransaction
+  alias NewRelixir.Instrumenters.Phoenix
+  alias Plug.Conn
+
+  @moduletag configured: true
+
+  setup %{configured: configured} do
+    previous_setting = Application.get_env(:new_relixir, :active)
+    Application.put_env(:new_relixir, :active, configured)
+    on_exit fn -> Application.put_env(:new_relixir, :active, previous_setting) end
+
+    :ok
+  end
+
+  test "it generates a transaction name based on controller and action names" do
+    conn =
+      %Conn{}
+      |> Conn.put_private(:phoenix_controller, SomeApplication.FakeController)
+      |> Conn.put_private(:phoenix_action, :test_action)
+
+    transaction = Phoenix.phoenix_controller_call(:start, %{}, %{conn: conn})
+
+    assert "FakeController#test_action" == transaction
+    assert {:ok, "FakeController#test_action"} == CurrentTransaction.get()
+  end
+
+  test "it records the elapsed time of the controller action in microseconds" do
+    :ok = Phoenix.phoenix_controller_call(:stop, 42_000_000, "SomeController#some_action")
+
+    [recorded_time] = get_metric_by_key({"SomeController#some_action", :total})
+
+    assert 42_000 == recorded_time
+  end
+
+  @tag configured: false
+  test "does not record a transaction when New Relic is not configured" do
+    nil = Phoenix.phoenix_controller_call(:stop, 42_000_000, "Controller#action")
+
+    assert {:error, :not_found} == CurrentTransaction.get()
+    assert [] == get_metric_keys()
+  end
+end

--- a/test/new_relixir/instrumenters/plug_test.exs
+++ b/test/new_relixir/instrumenters/plug_test.exs
@@ -1,0 +1,59 @@
+defmodule NewRelixir.Instrumenters.PlugTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  import TestHelpers.Assertions
+
+  alias NewRelixir.CurrentTransaction
+
+  @moduletag configured: true
+
+  defmodule FakePlugApp do
+    use Plug.Router
+
+    plug NewRelixir.Instrumenters.Plug
+
+    plug :match
+    plug :dispatch
+
+    get "/hello" do
+      conn = fetch_query_params(conn)
+      wait = conn.query_params["wait"]
+      if wait, do: wait |> String.to_integer |> :timer.sleep
+      send_resp(conn, 200, "Hello!")
+    end
+  end
+
+  setup %{configured: configured} do
+    previous_setting = Application.get_env(:new_relixir, :active)
+    Application.put_env(:new_relixir, :active, configured)
+    on_exit fn -> Application.put_env(:new_relixir, :active, previous_setting) end
+
+    :ok
+  end
+
+  test "it generates a transaction name based on request method and path" do
+    FakePlugApp.call(conn(:get, "/hello"), [])
+
+    assert {:ok, "hello#GET"} == CurrentTransaction.get()
+    assert [{"hello#GET", :total}] == get_metric_keys()
+  end
+
+  test "it records the elapsed time of the controller action" do
+    {elapsed_time, _} = :timer.tc(fn() ->
+      FakePlugApp.call(conn(:get, "/hello?wait=42"), [])
+    end)
+
+    [recorded_time] = get_metric_by_key({"hello#GET", :total})
+
+    assert_between(recorded_time, 42_000, elapsed_time)
+  end
+
+  @tag configured: false
+  test "does not record a transaction when New Relic is not configured" do
+    FakePlugApp.call(conn(:get, "/hello"), [])
+
+    assert {:error, :not_found} == CurrentTransaction.get()
+    assert [] == get_metric_keys()
+  end
+end

--- a/test/new_relixir/plug/instrumentation_test.exs
+++ b/test/new_relixir/plug/instrumentation_test.exs
@@ -1,5 +1,5 @@
 defmodule NewRelixir.Plug.InstrumentationTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
   import TestHelpers.Assertions
 

--- a/test/new_relixir/plug/instrumentation_test.exs
+++ b/test/new_relixir/plug/instrumentation_test.exs
@@ -1,18 +1,18 @@
 defmodule NewRelixir.Plug.InstrumentationTest do
   use ExUnit.Case, async: false
+
   import TestHelpers.Assertions
-  import Plug.Conn
-  require Ecto.Query
 
   alias NewRelixir.Plug.Instrumentation
+
+  require Ecto.Query
 
   @transaction_name "TestTransaction"
 
   setup do
-    conn = %Plug.Conn{}
-    |> put_private(:new_relixir_transaction, NewRelixir.Transaction.start(@transaction_name))
+    NewRelixir.CurrentTransaction.set(@transaction_name)
 
-    {:ok, conn: conn}
+    {:ok, conn: %Plug.Conn{}}
   end
 
   # query names
@@ -76,12 +76,14 @@ defmodule NewRelixir.Plug.InstrumentationTest do
   # with no transaction
 
   test "instrument_db does not record elapsed time when transaction is not present" do
+    Process.delete(:new_relixir_transaction)
     get_metric_keys()
     Instrumentation.instrument_db(:foo, %Ecto.Query{}, [conn: %Plug.Conn{}], fn -> nil end)
-    assert Enum.empty?(get_metric_keys())
+    assert [] == get_metric_keys()
   end
 
   test "instrument_db returns value of instrumented function when transaction is not present" do
+    Process.delete(:new_relixir_transaction)
     return_value = Instrumentation.instrument_db(:foo, %Ecto.Query{}, [conn: %Plug.Conn{}], fn ->
       42
     end)

--- a/test/new_relixir/plug/phoenix_test.exs
+++ b/test/new_relixir/plug/phoenix_test.exs
@@ -1,8 +1,10 @@
 defmodule NewRelixir.Plug.PhoenixTest do
   use ExUnit.Case, async: false
-  import TestHelpers.Assertions
 
   import Plug.Conn
+  import TestHelpers.Assertions
+
+  alias NewRelixir.CurrentTransaction
 
   @moduletag configured: true
 
@@ -18,14 +20,9 @@ defmodule NewRelixir.Plug.PhoenixTest do
     {:ok, conn: conn}
   end
 
-  test "it assigns a transaction to the connection", %{conn: conn} do
-    conn = NewRelixir.Plug.Phoenix.call(conn, nil)
-    assert_is_struct(conn.private[:new_relixir_transaction], NewRelixir.Transaction)
-  end
-
   test "it generates a transaction name based on controller and action names", %{conn: conn} do
-    conn = NewRelixir.Plug.Phoenix.call(conn, nil)
-    assert conn.private[:new_relixir_transaction].name == "FakeController#test_action"
+    NewRelixir.Plug.Phoenix.call(conn, [])
+    assert {:ok, "FakeController#test_action"} == CurrentTransaction.get()
   end
 
   test "it records the elapsed time of the controller action", %{conn: conn} do

--- a/test/new_relixir/plug/phoenix_test.exs
+++ b/test/new_relixir/plug/phoenix_test.exs
@@ -1,10 +1,10 @@
 defmodule NewRelixir.Plug.PhoenixTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
-  import Plug.Conn
   import TestHelpers.Assertions
 
   alias NewRelixir.CurrentTransaction
+  alias Plug.Conn
 
   @moduletag configured: true
 
@@ -13,9 +13,10 @@ defmodule NewRelixir.Plug.PhoenixTest do
     Application.put_env(:new_relixir, :active, configured)
     on_exit fn -> Application.put_env(:new_relixir, :active, previous_setting) end
 
-    conn = %Plug.Conn{}
-    |> put_private(:phoenix_controller, SomeApplication.FakeController)
-    |> put_private(:phoenix_action, :test_action)
+    conn =
+      %Conn{}
+      |> Conn.put_private(:phoenix_controller, SomeApplication.FakeController)
+      |> Conn.put_private(:phoenix_action, :test_action)
 
     {:ok, conn: conn}
   end

--- a/test/new_relixir/transaction_test.exs
+++ b/test/new_relixir/transaction_test.exs
@@ -1,69 +1,34 @@
 defmodule NewRelixir.TransactionTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
+
   import TestHelpers.Assertions
 
   alias NewRelixir.Transaction
 
-  @name "Test Transaction"
+  describe "record_web/2" do
+    test "adds web transactions to the collector" do
+      Transaction.record_web("a-web-transaction", 1_234)
+      Transaction.record_web("a-web-transaction", 2_345)
 
-  # finish
-
-  test "finish records elapsed time with correct key" do
-    transaction = Transaction.start(@name)
-    Transaction.finish(transaction)
-
-    assert_contains(get_metric_keys(), {@name, :total})
+      assert [2_345, 1_234] == get_metric_by_key({"a-web-transaction", :total})
+    end
   end
 
-  test "finish records accurate elapsed time" do
-    {_, elapsed_time} = :timer.tc(fn() ->
-      transaction = Transaction.start(@name)
-      :ok = :timer.sleep(42)
-      Transaction.finish(transaction)
-    end)
+  describe "record_db/3" do
+    test "adds database segments to the collector" do
+      Transaction.record_db("a-db-transaction", "Blog.Post.get", 1_234)
+      Transaction.record_db("a-db-transaction", "Blog.Post.get", 2_345)
 
-    [recorded_time] = get_metric_by_key({@name, :total})
-
-    assert_between(recorded_time, 42000, elapsed_time)
+      assert [2_345, 1_234] == get_metric_by_key({"a-db-transaction", {:db, "Blog.Post.get"}})
+    end
   end
 
-  # record_db
+  describe "record_external/3" do
+    test "adds web transactions to the collector" do
+      Transaction.record_external("an-ext-transaction", "a-host.com", 1_234)
+      Transaction.record_external("an-ext-transaction", "a-host.com", 2_345)
 
-  @model "SomeModel"
-  @action "get"
-  @elapsed 42
-
-  test "record_db records query time with correct key when given model and action tuple" do
-    transaction = Transaction.start(@name)
-    Transaction.record_db(transaction, {@model, @action}, @elapsed)
-
-    assert_contains(get_metric_keys(), {@name, {:db, "#{@model}.#{@action}"}})
-  end
-
-  test "record_db records accurate query time when given model and action tuple" do
-    transaction = Transaction.start(@name)
-    Transaction.record_db(transaction, {@model, @action}, @elapsed)
-
-    [recorded_time] = get_metric_by_key({@name, {:db, "#{@model}.#{@action}"}})
-
-    assert recorded_time == @elapsed
-  end
-
-  @query "FooBar"
-
-  test "record_db records query time with correct key when given a string" do
-    transaction = Transaction.start(@name)
-    Transaction.record_db(transaction, @query, @elapsed)
-
-    assert_contains(get_metric_keys(), {@name, {:db, @query}})
-  end
-
-  test "record_db records accurate query time when given a string" do
-    transaction = Transaction.start(@name)
-    Transaction.record_db(transaction, @query, @elapsed)
-
-    [recorded_time] = get_metric_by_key({@name, {:db, @query}})
-
-    assert recorded_time == @elapsed
+      assert [2_345, 1_234] == get_metric_by_key({"an-ext-transaction", {:ext, "a-host.com"}})
+    end
   end
 end


### PR DESCRIPTION
This PR replaces the plug-based instrumentation code with an alternative provided by Phoenix: [Endpoint instrumentation](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-instrumentation).

By using Phoenix instrumenters we offload part of the work on calculating elapsed time to Phoenix itself, note that we no longer rely on the `Transaction` module for that and record straight to `Collector` instead.

From now on `NewRelixir.Plug.Phoenix` gets deprecated and users of Plug-based frameworks other than Phoenix will be able to instrument their endpoints with `NewRelixir.Instrumenters.Plug`.

There is still some work to do before closing this and cutting the next release:

- [x] Track current transaction to ensure Ecto instrumentation still works.
- [x] Add some unit tests.
- [x] Update the README with setup instructions for the new instrumenter.
- [x] Update the CHANGELOG.
- [x] Improve documentation.
- [x] ~Make the dependencies on Phoenix and Plug optional.~ (separate PR)