### PR TITLE
from https://hex.pm/packages/new_relixir, current version is 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Phoenix application named `MyApp`.
       end
 
       defp deps do
-        [{:new_relixir, "~> 0.4.0"}]
+        [{:new_relixir, "~> 0.2.1"}]
       end
     end
     ```


### PR DESCRIPTION
Thanks for your such work. there is something wrong with the README file, current version is 0.2.1 from https://hex.pm/packages/new_relixir.

Thanks