### PR TITLE
Update build configuration to run against Elixir 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: elixir
-elixir:
-  - 1.2.2
-otp_release:
-  - 18.2.1
+matrix:
+  include:
+    - otp_release: 18.3
+      elixir: 1.2.6
+    - otp_release: 19.2
+      elixir: 1.4.0
+    - otp_release: 20.0
+      elixir: 1.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 18.3
-      elixir: 1.2.6
-    - otp_release: 19.2
-      elixir: 1.4.0
     - otp_release: 20.0
       elixir: 1.5.3


### PR DESCRIPTION
This fixes the automatic travis builds. new-relixir specifies it requires at least Elixir 1.5 but travis was running against 1.2.2.

https://travis-ci.org/TheRealReal/new-relixir

Someone with admin rights should probably re-enable the Github integration with travis as it doesn't seem to report build status back to pull requests anymore.