### PR TITLE
Replace invalid `Map.t` type with `map` type

### DIFF
--- a/lib/new_relixir/plug/repo.ex
+++ b/lib/new_relixir/plug/repo.ex
@@ -57,14 +57,14 @@ defmodule NewRelixir.Plug.Repo do
         end)
       end
 
-      @spec get_by(Ecto.Queryable.t, Keyword.t | Map.t, Keyword.t) :: Ecto.Schema.t | nil | no_return
+      @spec get_by(Ecto.Queryable.t, Keyword.t | map, Keyword.t) :: Ecto.Schema.t | nil | no_return
       def get_by(queryable, clauses, opts \\ []) do
         instrument_db(:get_by, queryable, opts, fn() ->
           repo().get_by(queryable, clauses, opts)
         end)
       end
 
-      @spec get_by!(Ecto.Queryable.t, Keyword.t | Map.t, Keyword.t) :: Ecto.Schema.t | nil | no_return
+      @spec get_by!(Ecto.Queryable.t, Keyword.t | map, Keyword.t) :: Ecto.Schema.t | nil | no_return
       def get_by!(queryable, clauses, opts \\ []) do
         instrument_db(:get_by!, queryable, opts, fn() ->
           repo().get_by!(queryable, clauses, opts)


### PR DESCRIPTION
Hello and thanks for your work on this library.

My team is using this library along with dialyzer, and we encountered this error after adding new-relixir:

```
:0: Unknown type 'Elixir.Map':t/0
```

I am making this PR to replace the `Map.t` type with the `map` type.