### PR TITLE
start collector supervised in each test case

### DIFF
--- a/test/new_relixir/instrumenters/phoenix_test.exs
+++ b/test/new_relixir/instrumenters/phoenix_test.exs
@@ -9,6 +9,11 @@ defmodule NewRelixir.Instrumenters.PhoenixTest do
 
   @moduletag configured: true
 
+  setup do
+    start_supervised(NewRelixir.Collector)
+    :ok
+  end
+
   setup %{configured: configured} do
     previous_setting = Application.get_env(:new_relixir, :active)
     Application.put_env(:new_relixir, :active, configured)

--- a/test/new_relixir/instrumenters/plug_test.exs
+++ b/test/new_relixir/instrumenters/plug_test.exs
@@ -24,6 +24,11 @@ defmodule NewRelixir.Instrumenters.PlugTest do
     end
   end
 
+  setup do
+    start_supervised(NewRelixir.Collector)
+    :ok
+  end
+
   setup %{configured: configured} do
     previous_setting = Application.get_env(:new_relixir, :active)
     Application.put_env(:new_relixir, :active, configured)

--- a/test/new_relixir/plug/instrumentation_test.exs
+++ b/test/new_relixir/plug/instrumentation_test.exs
@@ -10,6 +10,7 @@ defmodule NewRelixir.Plug.InstrumentationTest do
   @transaction_name "TestTransaction"
 
   setup do
+    start_supervised(NewRelixir.Collector)
     NewRelixir.CurrentTransaction.set(@transaction_name)
 
     {:ok, conn: %Plug.Conn{}}
@@ -77,7 +78,6 @@ defmodule NewRelixir.Plug.InstrumentationTest do
 
   test "instrument_db does not record elapsed time when transaction is not present" do
     Process.delete(:new_relixir_transaction)
-    get_metric_keys()
     Instrumentation.instrument_db(:foo, %Ecto.Query{}, [conn: %Plug.Conn{}], fn -> nil end)
     assert [] == get_metric_keys()
   end

--- a/test/new_relixir/plug/phoenix_test.exs
+++ b/test/new_relixir/plug/phoenix_test.exs
@@ -27,6 +27,8 @@ defmodule NewRelixir.Plug.PhoenixTest do
   end
 
   test "it records the elapsed time of the controller action", %{conn: conn} do
+    start_supervised(NewRelixir.Collector)
+
     {_, elapsed_time} = :timer.tc(fn() ->
       conn = NewRelixir.Plug.Phoenix.call(conn, nil)
       :ok = :timer.sleep(42)

--- a/test/new_relixir/plug/repo_test.exs
+++ b/test/new_relixir/plug/repo_test.exs
@@ -1,5 +1,5 @@
 defmodule NewRelixir.Plug.RepoTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case
 
   defmodule FakeRepo do
     @behaviour Ecto.Repo
@@ -132,11 +132,11 @@ defmodule NewRelixir.Plug.RepoTest do
 
   alias NewRelixir.Plug.RepoTest.FakeRepo.NewRelic, as: Repo
 
-  @transaction_name "TestTransaction"
+  @transaction_name "TestRepoTransaction"
 
   setup do
     NewRelixir.CurrentTransaction.set(@transaction_name)
-
+    start_supervised(NewRelixir.Collector)
     :ok
   end
 

--- a/test/new_relixir/transaction_test.exs
+++ b/test/new_relixir/transaction_test.exs
@@ -4,6 +4,10 @@ defmodule NewRelixir.TransactionTest do
   import TestHelpers.Assertions
 
   alias NewRelixir.Transaction
+  setup do
+    start_supervised(NewRelixir.Collector)
+    :ok
+  end
 
   describe "record_web/2" do
     test "adds web transactions to the collector" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -30,4 +30,3 @@ defmodule FakeModel do
 end
 
 ExUnit.start()
-NewRelixir.Collector.start_link()


### PR DESCRIPTION
having one collector run for the whole suite allows a race condition, instead, start and stop NewRelixir.Collector with each test