### PR TITLE
Add report_error and plug for exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,39 +104,40 @@ Phoenix application named `MyApp`.
     `MyApp.Repo.my_custom_operation/2` will be recorded to New Relic.
 
 ## Error Reporting
-   If you want to report all errors to new relic
+If you want to report all errors to new relic
 
-1.  Configure your router
-    ```elixir
-    # lib/my_app/router.ex
+Configure your router
 
-    defmodule MyApp.Router do
-      use MyApp, :router
-      use NewRelixir.Plug.Exception
+```elixir
+# lib/my_app/router.ex
 
-      ...
-    end
-    ```
+defmodule MyApp.Router do
+  use MyApp, :router
+  use NewRelixir.Plug.Exception
 
-    If you want to report caught errors
+  ...
+end
+```
 
-    ```elixir
-    try do
-      raise "oops"
-    catch
-      kind, reason ->
-        transaction =
-          case NewRelixir.CurrentTransaction.get() do
-            {:ok, transaction} -> transaction
-            {:error, _} -> NewRelixir.CurrentTransaction.set(conn.request_path)
-          end
+If you want to report caught errors
 
-        NewRelixir.Transaction.record_error(transaction, {kind, reason})
+```elixir
+try do
+  raise "oops"
+catch
+  kind, reason ->
+    transaction =
+      case NewRelixir.CurrentTransaction.get() do
+        {:ok, transaction} -> transaction
+        {:error, _} -> NewRelixir.CurrentTransaction.set(conn.request_path)
+      end
 
-        # You may want to re-raise this exception
-        :erlang.raise(kind, reason, System.stacktrace)
-    end
-    ```
+    NewRelixir.Transaction.record_error(transaction, {kind, reason})
+
+    # You may want to re-raise this exception
+    :erlang.raise(kind, reason, System.stacktrace)
+end
+```
 
 ## Upgrading from 0.3.x
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,41 @@ Phoenix application named `MyApp`.
     When using the wrapper module's `my_custom_operation`, the time it takes to call
     `MyApp.Repo.my_custom_operation/2` will be recorded to New Relic.
 
+## Error Reporting
+   If you want to report all errors to new relic
+
+1.  Configure your router
+    ```elixir
+    # lib/my_app/router.ex
+
+    defmodule MyApp.Router do
+      use MyApp, :router
+      use NewRelixir.Plug.Exception
+
+      ...
+    end
+    ```
+
+    If you want to report caught errors
+
+    ```elixir
+    try do
+      raise "oops"
+    catch
+      kind, reason ->
+        transaction =
+          case NewRelixir.CurrentTransaction.get() do
+            {:ok, transaction} -> transaction
+            {:error, _} -> NewRelixir.CurrentTransaction.set(conn.request_path)
+          end
+
+        NewRelixir.Transaction.record_error(transaction, {kind, reason})
+
+        # You may want to re-raise this exception
+        :erlang.raise(kind, reason, System.stacktrace)
+    end
+    ```
+
 ## Upgrading from 0.3.x
 
 1.  Remove `NewRelixir.Plug.Phoenix` from your Plug pipeline and all further references to

--- a/lib/new_relixir/collector.ex
+++ b/lib/new_relixir/collector.ex
@@ -11,8 +11,9 @@ defmodule NewRelixir.Collector do
     GenServer.cast(@name, {:record_value, {name, data}, elapsed})
   end
 
-  def record_error(transaction_name, {type, %{__exception__: true} = error}) do
-    GenServer.cast(@name, {:record_error, List.to_tuple(List.flatten([transaction_name, error_from_exception(type, error)]))})
+  def record_error(transaction_name, {type, %{__exception__: true} = exception}) do
+    {type, error} = error_from_exception(type, exception)
+    GenServer.cast(@name, {:record_error, {transaction_name, type, error}})
   end
   def record_error(transaction_name, {type, message}) do
     GenServer.cast(@name, {:record_error, {transaction_name, type, message}})
@@ -20,10 +21,10 @@ defmodule NewRelixir.Collector do
 
   defp error_from_exception(:error, exception) do
     normalized = Exception.normalize(:error, exception)
-    [normalized.__struct__, Exception.message(normalized)]
+    {normalized.__struct__, Exception.message(normalized)}
   end
   defp error_from_exception(type, exception) do
-    [type, Exception.format_banner(type, exception)]
+    {type, Exception.format_banner(type, exception)}
   end
 
   def pull do

--- a/lib/new_relixir/collector.ex
+++ b/lib/new_relixir/collector.ex
@@ -12,7 +12,7 @@ defmodule NewRelixir.Collector do
   end
 
   def record_error(transaction_name, {type, %{__exception__: true} = error}) do
-    GenServer.cast(@name, {:record_error, {transaction_name, error_from_exception(type, error)}})
+    GenServer.cast(@name, {:record_error, List.to_tuple(List.flatten([transaction_name, error_from_exception(type, error)]))})
   end
   def record_error(transaction_name, {type, message}) do
     GenServer.cast(@name, {:record_error, {transaction_name, type, message}})
@@ -20,10 +20,10 @@ defmodule NewRelixir.Collector do
 
   defp error_from_exception(:error, exception) do
     normalized = Exception.normalize(:error, exception)
-    {normalized.__struct__, Exception.message(normalized)}
+    [normalized.__struct__, Exception.message(normalized)]
   end
   defp error_from_exception(type, exception) do
-    {type, Exception.format_banner(type, exception)}
+    [type, Exception.format_banner(type, exception)]
   end
 
   def pull do

--- a/lib/new_relixir/collector.ex
+++ b/lib/new_relixir/collector.ex
@@ -11,8 +11,19 @@ defmodule NewRelixir.Collector do
     GenServer.cast(@name, {:record_value, {name, data}, elapsed})
   end
 
+  def record_error(transaction_name, {type, %{__exception__: true} = error}) do
+    GenServer.cast(@name, {:record_error, {transaction_name, error_from_exception(type, error)}})
+  end
   def record_error(transaction_name, {type, message}) do
     GenServer.cast(@name, {:record_error, {transaction_name, type, message}})
+  end
+
+  defp error_from_exception(:error, exception) do
+    normalized = Exception.normalize(:error, exception)
+    {normalized.__struct__, Exception.message(normalized)}
+  end
+  defp error_from_exception(type, exception) do
+    {type, Exception.format_banner(type, exception)}
   end
 
   def pull do

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -15,7 +15,7 @@ defmodule NewRelixir.Plug.Exception do
         end
       end
 
-      defp handle_errors(conn, %{kind: kind, reason: reason}) do
+      defp handle_errors(conn, %{kind: kind, reason: reason} = error) do
         transaction =
           case NewRelixir.CurrentTransaction.get() do
             {:ok, transaction} -> transaction
@@ -24,6 +24,7 @@ defmodule NewRelixir.Plug.Exception do
           end
 
         NewRelixir.Transaction.record_error(transaction, {kind, reason})
+        super(conn, error)
       end
 
       defoverridable handle_errors: 2

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -2,6 +2,7 @@ defmodule NewRelixir.Plug.Exception do
   defmacro __using__(_) do
     quote location: :keep do
       use Plug.ErrorHandler
+      import NewRelixir.Plug.Exception
 
       if :code.is_loaded(Phoenix) do
         defp handle_errors(_conn, %{reason: %Phoenix.Router.NoRouteError{}}) do
@@ -23,11 +24,14 @@ defmodule NewRelixir.Plug.Exception do
             _ -> nil
           end
 
-        NewRelixir.Transaction.record_error(transaction, {kind, reason})
-        super(conn, error)
+        apply(reporter(), :record_error, [transaction, {kind, reason}])
       end
 
       defoverridable handle_errors: 2
     end
+  end
+
+  def reporter do
+    Application.get_env(:new_relixir, :reporter, NewRelixir.Transaction)
   end
 end

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -1,5 +1,5 @@
 defmodule NewRelixir.Plug.Exception do
-  defmacro __using__ do
+  defmacro __using__(_) do
     quote location: :keep do
       use Plug.ErrorHandler
 
@@ -23,7 +23,7 @@ defmodule NewRelixir.Plug.Exception do
             _ -> nil
           end
 
-        NewRelixir.Transaction.notice_error(transaction, {kind, reason})
+        NewRelixir.Transaction.record_error(transaction, {kind, reason})
       end
 
       defoverridable handle_errors: 2

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -1,0 +1,32 @@
+defmodule NewRelixir.Plug.Exception do
+  defmacro __using__(env) do
+    quote location: :keep do
+      use Plug.ErrorHandler
+
+      # Ignore 404s for Plug routes
+      defp handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}}) do
+        nil
+      end
+
+      if :code.is_loaded(Phoenix) do
+        # Ignore 404s for Phoenix routes
+        defp handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}}) do
+          nil
+        end
+      end
+
+      defp handle_errors(conn, %{kind: kind, reason: reason}) do
+        transaction =
+          case NewRelixir.CurrentTransaction.get() do
+            {:ok, transaction} -> transaction
+            {:error, _} -> NewRelixir.CurrentTransaction.set(conn.request_path)
+            _ -> nil
+          end
+
+        NewRelixir.Transaction.notice_error(transaction, {kind, reason})
+      end
+
+      defoverridable handle_errors: 2
+    end
+  end
+end

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -1,5 +1,5 @@
 defmodule NewRelixir.Plug.Exception do
-  defmacro __using__(env) do
+  defmacro __using__ do
     quote location: :keep do
       use Plug.ErrorHandler
 

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -3,14 +3,14 @@ defmodule NewRelixir.Plug.Exception do
     quote location: :keep do
       use Plug.ErrorHandler
 
-      # Ignore 404s for Plug routes
-      defp handle_errors(conn, %{reason: %FunctionClauseError{function: :do_match}}) do
-        nil
+      if :code.is_loaded(Phoenix) do
+        defp handle_errors(_conn, %{reason: %Phoenix.Router.NoRouteError{}}) do
+          nil
+        end
       end
 
-      if :code.is_loaded(Phoenix) do
-        # Ignore 404s for Phoenix routes
-        defp handle_errors(conn, %{reason: %Phoenix.Router.NoRouteError{}}) do
+      if :code.is_loaded(Ecto) do
+        defp handle_errors(conn, %{reason: %Ecto.NoResultsError{}}) do
           nil
         end
       end

--- a/lib/new_relixir/stats.ex
+++ b/lib/new_relixir/stats.ex
@@ -14,17 +14,18 @@ defmodule NewRelixir.Stats do
     {[webtransaction_total(ms), db_total(ms) | errors_total(errs) ++ ms], errs, time}
   end
 
+  def transform_error_counter({{scope, {type, message}}, count}), do: transform_error_counter({{scope, type, message}, count})
   def transform_error_counter({{scope, type, message}, count}) do
     error = [
       :os.system_time(:micro_seconds) / 1_000_000,
       scope2bin(scope),
       to_string(message),
       to_string(type),
-      [%{
+      %{
         parameter_groups: %{},
         stack_trace: [],
         request_params: %{},
-        request_uri: scope}]
+        request_uri: scope}
     ]
     List.duplicate(error, count)
   end

--- a/lib/new_relixir/stats.ex
+++ b/lib/new_relixir/stats.ex
@@ -14,7 +14,6 @@ defmodule NewRelixir.Stats do
     {[webtransaction_total(ms), db_total(ms) | errors_total(errs) ++ ms], errs, time}
   end
 
-  def transform_error_counter({{scope, {type, message}}, count}), do: transform_error_counter({{scope, type, message}, count})
   def transform_error_counter({{scope, type, message}, count}) do
     error = [
       :os.system_time(:micro_seconds) / 1_000_000,

--- a/lib/new_relixir/transaction.ex
+++ b/lib/new_relixir/transaction.ex
@@ -8,8 +8,8 @@ defmodule NewRelixir.Transaction do
   @doc """
   Send an error to New Relic
   """
-  @spec notice_error(transaction :: binary, error :: {binary, binary}) :: :ok
-  def notice_error(transaction, {type, message})
+  @spec record_error(transaction :: binary, error :: {binary, binary}) :: :ok
+  def record_error(transaction, {type, message})
       when is_binary(transaction)
       and is_binary(message) do
     Collector.record_error(transaction, {type, message})
@@ -18,8 +18,8 @@ defmodule NewRelixir.Transaction do
   @doc """
   Send an exception to New Relic
   """
-  @spec notice_error(transaction :: binary, error :: {binary, Exception.t}) :: :ok
-  def notice_error(transaction, {type, exception})
+  @spec record_error(transaction :: binary, error :: {binary, Exception.t}) :: :ok
+  def record_error(transaction, {type, exception})
       when is_binary(transaction) do
     Collector.record_error(transaction, {type, exception})
   end

--- a/lib/new_relixir/transaction.ex
+++ b/lib/new_relixir/transaction.ex
@@ -8,20 +8,10 @@ defmodule NewRelixir.Transaction do
   @doc """
   Send an error to New Relic
   """
-  @spec record_error(transaction :: binary, error :: {binary, binary}) :: :ok
+  @spec record_error(transaction :: binary, error :: {binary, binary | Exception.t}) :: :ok
   def record_error(transaction, {type, message})
-      when is_binary(transaction)
-      and is_binary(message) do
+    when is_binary(transaction) do
     Collector.record_error(transaction, {type, message})
-  end
-
-  @doc """
-  Send an exception to New Relic
-  """
-  @spec record_error(transaction :: binary, error :: {binary, Exception.t}) :: :ok
-  def record_error(transaction, {type, exception})
-      when is_binary(transaction) do
-    Collector.record_error(transaction, {type, exception})
   end
 
   @doc """

--- a/lib/new_relixir/transaction.ex
+++ b/lib/new_relixir/transaction.ex
@@ -6,6 +6,25 @@ defmodule NewRelixir.Transaction do
   alias NewRelixir.Collector
 
   @doc """
+  Send an error to New Relic
+  """
+  @spec notice_error(transaction :: binary, error :: {binary, binary}) :: :ok
+  def notice_error(transaction, {type, message})
+      when is_binary(transaction)
+      and is_binary(message) do
+    Collector.record_error(transaction, {type, message})
+  end
+
+  @doc """
+  Send an exception to New Relic
+  """
+  @spec notice_error(transaction :: binary, error :: {binary, Exception.t}) :: :ok
+  def notice_error(transaction, {type, exception})
+      when is_binary(transaction) do
+    Collector.record_error(transaction, {type, exception})
+  end
+
+  @doc """
   Records the total time of a web transaction.
   """
   @spec record_web(transaction :: binary, elapsed_time :: integer) :: :ok

--- a/test/new_relixir/plug/exception_test.exs
+++ b/test/new_relixir/plug/exception_test.exs
@@ -1,0 +1,54 @@
+defmodule ExceptionTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  defmodule TestException do
+    defexception plug_status: 403, message: "oops"
+  end
+
+  defmodule ErrorRaisingPlug do
+    defmacro __using__(_env) do
+      quote do
+        def call(conn, _opts) do
+          raise Plug.Conn.WrapperError, conn: conn,
+          kind: :error, stack: System.stacktrace,
+          reason: TestException.exception([])
+        end
+      end
+    end
+  end
+
+  defmodule TestPlug do
+    use NewRelixir.Plug.Exception
+    use ErrorRaisingPlug
+  end
+
+  defmodule FakeReporter do
+    def record_error(transaction, exception) do
+      send self(), {:record_error, {transaction, exception}}
+    end
+  end
+
+  setup do
+    Application.put_env(:new_relixir, :reporter, FakeReporter)
+  end
+
+  test "Raising an error on failure" do
+    conn = conn(:get, "/")
+
+    assert_raise Plug.Conn.WrapperError, fn ->
+      TestPlug.call(conn, [])
+    end
+
+    assert_received {:record_error, {"/", {:error, %TestException{}}}}
+  end
+
+  test "Includes path data in report" do
+    conn = conn(:get, "/some_path")
+
+    catch_error TestPlug.call(conn, [])
+    assert_received {:record_error, {path, {:error, %TestException{}}}}
+
+    assert path == "/some_path"
+  end
+end

--- a/test/new_relixir/stats_test.exs
+++ b/test/new_relixir/stats_test.exs
@@ -35,12 +35,12 @@ defmodule NewRelixir.StatsTest do
       assert scope == "WebTransaction/Uri/home/index"
       assert message == "no function clause matching"
       assert error == "FunctionClauseError"
-      assert details == [%{
+      assert details == %{
         parameter_groups: %{},
         request_params: %{},
         request_uri: "home/index",
         stack_trace: []
-      }]
+      }
     end
   end
 end

--- a/test/new_relixir/transaction_test.exs
+++ b/test/new_relixir/transaction_test.exs
@@ -9,6 +9,13 @@ defmodule NewRelixir.TransactionTest do
     :ok
   end
 
+  describe "record_error/2" do
+    test "adds error to the collector" do
+      Transaction.record_error("a-web-transaction", {:error, "Something went wrong"})
+      assert %{{"a-web-transaction", :error, "Something went wrong"} => 1} == get_errors()
+    end
+  end
+
   describe "record_web/2" do
     test "adds web transactions to the collector" do
       Transaction.record_web("a-web-transaction", 1_234)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,6 +13,11 @@ defmodule TestHelpers.Assertions do
     assert is_map(value) && value.__struct__ == module, "expected #{module}, got #{inspect(value)}"
   end
 
+  def get_errors do
+    [_, _, _, errors] = NewRelixir.Collector.pull
+    errors
+  end
+
   def get_metric_keys(), do: Map.keys(get_metrics())
 
   def get_metric_by_key(key), do: get_metrics()[key]


### PR DESCRIPTION
Send exception data to new relic.

To report all exceptions, use add `use NewRelixir.Plug.Exception` in phoenix router.

To report a caught exception, use `Transaction.report_error/2`


### TODO: 
- [x] ~Does not support multiple error handlers~ Must call record_error directly

- [ ] Does not report stack trace.

