### PR TITLE
Collector: Add init/1 implementation

### DIFF
--- a/lib/new_relixir/collector.ex
+++ b/lib/new_relixir/collector.ex
@@ -6,6 +6,10 @@ defmodule NewRelixir.Collector do
   def start_link(_opts \\ []) do
     GenServer.start_link(@name, [current_time() | @default_state], name: @name)
   end
+  
+  def init(args) do
+    {:ok, args}
+  end
 
   def record_value({name, data}, elapsed) do
     GenServer.cast(@name, {:record_value, {name, data}, elapsed})


### PR DESCRIPTION
Addresses warning from Elixir 1.6:

```
warning: function init/1 required by behaviour GenServer is not implemented (in module NewRelixir.Collector).

We will inject a default implementation for now:

    def init(args) do
      {:ok, args}
    end

You can copy the implementation above or define your own that converts the arguments given to GenServer.start_link/3 to the server state.

  lib/new_relixir/collector.ex:1
```

See: https://github.com/elixir-lang/elixir/releases/tag/v1.6.0