### PR TITLE
Add guard to check that model type is not nil

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -52,7 +52,8 @@ defmodule NewRelixir.Plug.Instrumentation do
   defp infer_model(%{data: data}) do #ecto 2.0
     infer_model(data)
   end
-  defp infer_model(%Ecto.Query{from: {_, model_type}}) do
+
+  defp infer_model(%Ecto.Query{from: {_, model_type}}) when not is_nil(model_type) do
     short_module_name(model_type)
   end
   defp infer_model(%Ecto.Query{}) do

--- a/test/new_relixir/plug/instrumentation_test.exs
+++ b/test/new_relixir/plug/instrumentation_test.exs
@@ -54,6 +54,12 @@ defmodule NewRelixir.Plug.InstrumentationTest do
     assert_contains(get_metric_keys(), {@transaction_name, {:db, "SQL"}})
   end
 
+  test "instrument_db records query as SQL when query has no model", %{conn: conn} do
+    query = Ecto.Query.from("fake_table", select: [:id])
+    Instrumentation.instrument_db(:foo, query, [conn: conn], fn -> nil end)
+    assert_contains(get_metric_keys(), {@transaction_name, {:db, "SQL"}})
+  end
+
   # with transaction
 
   test "instrument_db records accurate elapsed time", %{conn: conn} do


### PR DESCRIPTION
Currently, executing a schemaless query, such as `Ecto.Query.from("some_table", select: [:id])` results in an exception:
```
** (ArgumentError) expected an Elixir module, got: nil
     code: Instrumentation.instrument_db(:foo, query, [conn: conn], fn -> nil end)
     stacktrace:
       (elixir) lib/module.ex:1202: Module.split/2
       lib/new_relixir/utils.ex:11: NewRelixir.Utils.short_module_name/1
       lib/new_relixir/plug/instrumentation.ex:37: NewRelixir.Plug.Instrumentation.put_model/2
       lib/new_relixir/plug/instrumentation.ex:26: NewRelixir.Plug.Instrumentation.instrument_db/4
```

This PR adds a test for that case and fixes the issue by adding a guard clause to check that model name is not nil.