### PR TITLE
Adjust instruction for Elixir version >= 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and database queries.
 The following instructions show how to add instrumentation with New Relixir to a hypothetical
 Phoenix application named `MyApp`.
 
-1.  Add `new_relixir` to your list of dependencies and start-up applications in `mix.exs`:
+1.  Add `new_relixir` to your list of dependencies in `mix.exs`:
 
     ```elixir
     # mix.exs
@@ -23,16 +23,23 @@ Phoenix application named `MyApp`.
 
       # ...
 
-      def application do
-        [mod: {MyApp, []},
-         applications: [:new_relixir]]
-      end
-
       defp deps do
         [{:new_relixir, "~> 0.4"}]
       end
     end
     ```
+
+    If you use the `applications` key (only for apps created before Elixir 1.4) in
+    `def application do`, then you will also need to add `new_relixir` to it:
+
+    ```elixir
+    def application do
+      [mod: {MyApp, []},
+       applications: [:new_relixir]]
+    end
+    ```
+
+    If your app does not have an `applications` key, skip this instruction.
 
 2.  Add your New Relic application name and license key to `config/config.exs`. You may wish to use
     environment variables to keep production, staging, and development environments separate:


### PR DESCRIPTION
Cleans up instruction that will trip up most users of this package if they create a release of their application.

Setting the `applications` key in `def application` in mix.exs prevents Mix (>= 1.4) from inferring applications that need to be added to a release.

See "Application inference" section in https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/ for details. The important detail is: "Mix v1.4 now automatically infers your applications list as long as you leave the :applications key empty.".