### PR TITLE
Support registered processes as ancestors

### DIFF
--- a/lib/new_relixir/current_transaction.ex
+++ b/lib/new_relixir/current_transaction.ex
@@ -33,6 +33,7 @@ defmodule NewRelixir.CurrentTransaction do
     Process.put(@key, transaction)
     transaction
   end
+
   def set(_), do: nil
 
   # Getting the other processes info generate locks. That's why this
@@ -45,10 +46,16 @@ defmodule NewRelixir.CurrentTransaction do
     |> set
   end
 
-  defp extract_transaction(pid) do
-    case Process.info(pid, :dictionary) do
+  defp extract_transaction(ancestor) do
+    ancestor
+    |> locate_process()
+    |> Process.info(:dictionary)
+    |> case do
       {:dictionary, info} -> info[@key]
       _ -> nil
     end
   end
+
+  defp locate_process(pid) when is_pid(pid), do: pid
+  defp locate_process(atom) when is_atom(atom), do: Process.whereis(atom)
 end


### PR DESCRIPTION
The ancestry tree fetched from the current process dictionary may contain some registered process names (atoms), rather than just PIDs. In that case New Relixir would crash with this error:

    ** (ArgumentError) argument error
        :erlang.process_info(:named_ancestor, :dictionary)
        (elixir) lib/process.ex:646: Process.info/2
        lib/new_relixir/current_transaction.ex:51: NewRelixir.CurrentTransaction.extract_transaction/1
        (elixir) lib/enum.ex:2914: Enum.find_value_list/3
        lib/new_relixir/current_transaction.ex:44: NewRelixir.CurrentTransaction.search_on_ancestors/0
        lib/new_relixir/current_transaction.ex:21: NewRelixir.CurrentTransaction.get/0
        (elixir) lib/task/supervised.ex:88: Task.Supervised.do_apply/2
        (elixir) lib/task/supervised.ex:38: Task.Supervised.reply/5
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
    Function: &NewRelixir.CurrentTransaction.get/0
        Args: []

Fixes #57.