### PR TITLE
Update repo transaction spec to match the callback from Ecto

### DIFF
--- a/lib/new_relixir/plug/repo.ex
+++ b/lib/new_relixir/plug/repo.ex
@@ -26,9 +26,12 @@ defmodule NewRelixir.Plug.Repo do
 
       import NewRelixir.Plug.Instrumentation
 
-      @spec transaction(fun, Keyword.t) :: {:ok, any} | {:error, any}
-      def transaction(fun, opts \\ []) when is_list(opts) do
-        repo().transaction(fun, opts)
+      @spec transaction(fun_or_multi :: fun | Ecto.Multi.t(), opts :: Keyword.t()) ::
+              {:ok, any}
+              | {:error, any}
+              | {:error, Ecto.Multi.name(), any, %{Ecto.Multi.name() => any}}
+      def transaction(fun_or_multi, opts \\ []) when is_list(opts) do
+        repo().transaction(fun_or_multi, opts)
       end
 
       @spec rollback(any) :: no_return


### PR DESCRIPTION
This is updating the type spec for NewRelixir.Plug.Repo.transaction to match the callback definition in Ecto.

Ecto 2.2.10: https://github.com/elixir-ecto/ecto/blob/v2.2.10/lib/ecto/repo.ex#L1026