### PR TITLE
Allowing instrumentation of Ecto.Adapters.SQL.query

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -18,6 +18,17 @@ defmodule NewRelixir.Plug.Instrumentation do
   By default, the query name will be inferred from `queryable` and `action`. This
   can be overriden by providing a `:query` option in `opts`.
   """
+  @spec instrument_db(atom, String.t(), [term()], Keyword.t(), fun) :: any
+  def instrument_db(action, sql, params, opts, f) do
+    {elapsed, result} = :timer.tc(f)
+
+    opts
+    |> Keyword.put(:query, sql)
+    |> record(elapsed)
+
+    result
+  end
+
   @spec instrument_db(atom, Ecto.Queryable.t, Keyword.t, fun) :: any
   def instrument_db(action, queryable, opts, f) do
     {elapsed, result} = :timer.tc(f)

--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -10,8 +10,9 @@ defmodule NewRelixir.Plug.Instrumentation do
   @doc """
   Instruments a database call and records the elapsed time.
 
-  * `action` is the name of the repository function being instrumented.
-  * `queryable` is the `Queryable` being passed to the repository.
+  * `action` is the name of the operation being instrumented.
+  * `sql` is the `SQL Instruction` being passed to the transaction recorder.
+  * `params` a list of parameters to be used on the prepared statement.
   * `opts` is a keyword list of overrides to parts of the recorded transaction name.
   * `f` is the function to be instrumented.
 
@@ -29,6 +30,17 @@ defmodule NewRelixir.Plug.Instrumentation do
     result
   end
 
+  @doc """
+  Instruments a database call and records the elapsed time.
+
+  * `action` is the name of the repository function being instrumented.
+  * `queryable` is the `Queryable` being passed to the repository.
+  * `opts` is a keyword list of overrides to parts of the recorded transaction name.
+  * `f` is the function to be instrumented.
+
+  By default, the query name will be inferred from `queryable` and `action`. This
+  can be overriden by providing a `:query` option in `opts`.
+  """
   @spec instrument_db(atom, Ecto.Queryable.t, Keyword.t, fun) :: any
   def instrument_db(action, queryable, opts, f) do
     {elapsed, result} = :timer.tc(f)

--- a/lib/new_relixir/plug/repo.ex
+++ b/lib/new_relixir/plug/repo.ex
@@ -164,6 +164,33 @@ defmodule NewRelixir.Plug.Repo do
         end)
       end
 
+      @spec query(String.t(), [term()], Keyword.t()) ::
+        {:ok,
+         %{
+           :rows => nil | [[term()] | binary()],
+           :num_rows => non_neg_integer(),
+           optional(atom()) => any()
+         }}
+        | {:error, Exception.t()}
+      def query(sql, params \\ [], opts \\ []) do
+        instrument_db(:query, sql, params, opts, fn() ->
+          repo().query(sql, params, opts)
+        end)
+      end
+
+      @spec query!(String.t(), [term()], Keyword.t()) ::
+        %{
+          :rows => nil | [[term()] | binary()],
+          :num_rows => non_neg_integer(),
+          optional(atom()) => any()
+        }
+        | no_return()
+      def query!(sql, params \\ [], opts \\ []) do
+        instrument_db(:query!, sql, params, opts, fn() ->
+          repo().query!(sql, params, opts)
+        end)
+      end
+
       @spec aggregate(Ecto.Queryable.t, :avg | :count | :max | :min | :sum, atom, Keyword.t) :: term | nil
       def aggregate(queryable, aggregate, field, opts \\ []) do
         instrument_db(:aggregate, queryable, opts, fn() ->

--- a/test/new_relixir/plug/repo_test.exs
+++ b/test/new_relixir/plug/repo_test.exs
@@ -103,6 +103,14 @@ defmodule NewRelixir.Plug.RepoTest do
       record_call(:preload, [model_or_models, preloads, opts])
     end
 
+    def query(sql, params \\ [], opts \\ []) do
+      record_call(:query, [sql, params, opts])
+    end
+
+    def query!(sql, params \\ [], opts \\ []) do
+      record_call(:query!, [sql, params, opts])
+    end
+
     def __adapter__ do
     end
 
@@ -465,6 +473,38 @@ defmodule NewRelixir.Plug.RepoTest do
       [recorded_time | _] = get_metric_by_key({@transaction_name, {:db, "FakeModel.preload"}})
       assert_between(recorded_time, sleep_time, elapsed_time)
     end
+  end
+
+  # query
+
+  test "query calls repo's query method" do
+    assert Repo.query("my_query", ["param"]) == FakeRepo.query("my_query", ["param"])
+  end
+
+  test "records time to call repo's query method" do
+    {elapsed_time, sleep_time} = :timer.tc(fn ->
+      {time, _, _} = Repo.query("my_query", ["param"])
+      time
+    end)
+
+    [recorded_time | _] = get_metric_by_key({@transaction_name, {:db, "my_query"}})
+    assert_between(recorded_time, sleep_time, elapsed_time)
+  end
+
+  # query!
+
+  test "query! calls repo's query method" do
+    assert Repo.query!("my_query", ["param"]) == FakeRepo.query!("my_query", ["param"])
+  end
+
+  test "records time to call repo's query! method" do
+    {elapsed_time, sleep_time} = :timer.tc(fn ->
+      {time, _, _} = Repo.query!("my_query", ["param"])
+      time
+    end)
+
+    [recorded_time | _] = get_metric_by_key({@transaction_name, {:db, "my_query"}})
+    assert_between(recorded_time, sleep_time, elapsed_time)
   end
 
   # transaction


### PR DESCRIPTION
It's actualy not possible to isstrument `Repo.query`, which allows to run plain SQL like **Stored Procedures** and **Functions** invokation. This PR aims to solve this.