### PR TITLE
Fix: not passing `opts` to Repo.preload/3

### DIFF
--- a/lib/new_relixir/plug/repo.ex
+++ b/lib/new_relixir/plug/repo.ex
@@ -174,7 +174,7 @@ defmodule NewRelixir.Plug.Repo do
       @spec preload([Ecto.Schema.t] | Ecto.Schema.t, preloads :: term) :: [Ecto.Schema.t] | Ecto.Schema.t
       def preload(model_or_models, preloads, opts \\ []) do
         instrument_db(:preload, model_or_models, opts, fn() ->
-          repo().preload(model_or_models, preloads)
+          repo().preload(model_or_models, preloads, opts)
         end)
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,8 +10,8 @@ defmodule NewRelixir.Mixfile do
       description: "New Relic tracking for Phoenix and Plug applications.",
       package: package(),
       source_url: "https://github.com/TheRealReal/new-relixir",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps()
     ]
@@ -43,6 +43,6 @@ defmodule NewRelixir.Mixfile do
   end
 
   defp aliases do
-    ["test": ["test --no-start"]]
+    [test: ["test --no-start"]]
   end
 end

--- a/test/new_relixir/plug/repo_test.exs
+++ b/test/new_relixir/plug/repo_test.exs
@@ -449,7 +449,8 @@ defmodule NewRelixir.Plug.RepoTest do
 
   describe "preload/3" do
     test "calls repo's preload method" do
-      assert Repo.preload(%FakeModel{}, [:foo, :bar]) == FakeRepo.preload(%FakeModel{}, [:foo, :bar])
+      assert Repo.preload(%FakeModel{}, [:foo, :bar], force: true) ==
+               FakeRepo.preload(%FakeModel{}, [:foo, :bar], force: true)
     end
 
     test "works with list of structs"  do


### PR DESCRIPTION
The 3rd argument to `Repo.preload/3` wasn't getting passed to the underlying repo. This fixes that, and fixes a warning in mix.exs that's related to Elixir 1.7.