### PR TITLE
background transaction interface

### DIFF
--- a/lib/new_relixir/current_transaction.ex
+++ b/lib/new_relixir/current_transaction.ex
@@ -34,6 +34,11 @@ defmodule NewRelixir.CurrentTransaction do
     transaction
   end
 
+  def set({:background, transaction}) when is_binary(transaction) do
+    Process.put(@key, {:background, transaction})
+    transaction
+  end
+
   def set(_), do: nil
 
   # Getting the other processes info generate locks. That's why this

--- a/lib/new_relixir/transaction.ex
+++ b/lib/new_relixir/transaction.ex
@@ -36,7 +36,7 @@ defmodule NewRelixir.Transaction do
   end
 
   @doc """
-  Records an external HTTP call made in a web transaction.
+  Records an external HTTP call made in a transaction.
   """
   @spec record_external(transaction :: binary, host :: binary, elapsed_time :: integer) :: :ok
   def record_external(transaction, host, elapsed_time)
@@ -44,5 +44,15 @@ defmodule NewRelixir.Transaction do
       and is_binary(host)
       and is_integer(elapsed_time) do
     Collector.record_value({transaction, {:ext, host}}, elapsed_time)
+  end
+
+  def record_external({:background, transaction}, host, elapsed_time)
+    when is_binary(host) 
+    and is_integer(elapsed_time) do
+    Collector.record_value({{:background, transaction}, {:external, host}}, elapsed_time)
+  end
+
+  def record_background(transaction, elapsed_time) do
+    Collector.record_value({{:background, transaction}, :total}, elapsed_time)
   end
 end


### PR DESCRIPTION
it is possible to record background transactions by setting the transaction key as shown below.

Opening this PR to get feedback on how to best expose this interface.

This could also be accomplished be done by simply removing the is_binary guard clause [here](https://github.com/TheRealReal/new-relixir/compare/feature/background-transaction-interface?expand=1#diff-a6366d0c762a4a27da2e01a08c37cdf8R32) and adding documentation about how to call Collector directly as [here](https://github.com/TheRealReal/new-relixir/compare/feature/background-transaction-interface?expand=1#diff-ab45cb50e75f40ec0733750841d2b295R50), but an interface on the transaction module may be nice.

The data will show up in the background jobs report.
![screen shot 2018-08-03 at 2 15 05 pm](https://user-images.githubusercontent.com/32463466/43666190-a37c8840-9727-11e8-9c3d-44bfe49f3ca9.png)