### PR TITLE
Set default language of agent to elixir

### DIFF
--- a/lib/new_relixir/agent.ex
+++ b/lib/new_relixir/agent.ex
@@ -48,7 +48,7 @@ defmodule NewRelixir.Agent do
       :identifier => app_name(),
       :pid => l2i(:os.getpid()),
       :environment => [],
-      :language => Application.get_env(:new_relixir, :language, "python"),
+      :language => Application.get_env(:new_relixir, :language, "elixir"),
       :settings => %{}
     }]
 


### PR DESCRIPTION
Just noticed that the default language set when the Agent connects is `python`. Changing it to `elixir`.