### PR TITLE
Use the same transaction naming schema for errors

### DIFF
--- a/lib/new_relixir/instrumenters/plug.ex
+++ b/lib/new_relixir/instrumenters/plug.ex
@@ -26,7 +26,7 @@ defmodule NewRelixir.Instrumenters.Plug do
 
   @behaviour Plug
 
-  alias NewRelixir.{CurrentTransaction, Transaction}
+  alias NewRelixir.{CurrentTransaction, Transaction, Utils}
   alias Plug.Conn
 
   def init(opts), do: opts
@@ -39,8 +39,8 @@ defmodule NewRelixir.Instrumenters.Plug do
     end
   end
 
-  defp record_transaction(%Conn{request_path: "/" <> path, method: method} = conn) do
-    transaction = "#{path}##{method}"
+  defp record_transaction(conn) do
+    transaction = Utils.transaction_name(conn)
     CurrentTransaction.set(transaction)
 
     start = System.monotonic_time()

--- a/lib/new_relixir/plug/exception.ex
+++ b/lib/new_relixir/plug/exception.ex
@@ -20,7 +20,7 @@ defmodule NewRelixir.Plug.Exception do
         transaction =
           case NewRelixir.CurrentTransaction.get() do
             {:ok, transaction} -> transaction
-            {:error, _} -> NewRelixir.CurrentTransaction.set(conn.request_path)
+            {:error, _} -> NewRelixir.Utils.transaction_name(conn)
           end
 
         apply(reporter(), :record_error, [transaction, {kind, reason}])

--- a/lib/new_relixir/utils.ex
+++ b/lib/new_relixir/utils.ex
@@ -1,16 +1,28 @@
 defmodule NewRelixir.Utils do
-  import Phoenix.Controller, only: [controller_module: 1, action_name: 1]
+  alias Plug.Conn
 
-  def transaction_name(conn) do
-    module = conn |> controller_module |> short_module_name
-    action = conn |> action_name
-    "#{module}##{action}"
+  @doc """
+  Derives a transaction name from the current context.
+
+  If in a Phoenix app, it is composed of controller and action name.
+  If in a Plug-only app, it is made out of request path and method.
+  """
+  def transaction_name(%Conn{private: %{phoenix_action: action, phoenix_controller: controller}}) do
+    "#{short_module_name(controller)}##{action}"
   end
 
+  def transaction_name(%Conn{request_path: "/" <> path, method: method}) do
+    "#{path}##{method}"
+  end
+
+  def transaction_name(_), do: nil
+
   def short_module_name(module) do
-    module |> Module.split |> join_without_prefix
+    module
+    |> Module.split()
+    |> join_without_prefix()
   end
 
   defp join_without_prefix([module_name]), do: module_name
-  defp join_without_prefix([_|name_parts]), do: Enum.join(name_parts, ".")
+  defp join_without_prefix([_ | name_parts]), do: Enum.join(name_parts, ".")
 end

--- a/test/new_relixir/plug/exception_test.exs
+++ b/test/new_relixir/plug/exception_test.exs
@@ -34,21 +34,21 @@ defmodule ExceptionTest do
   end
 
   test "Raising an error on failure" do
-    conn = conn(:get, "/")
+    conn = conn(:get, "/path")
 
     assert_raise Plug.Conn.WrapperError, fn ->
       TestPlug.call(conn, [])
     end
 
-    assert_received {:record_error, {"/", {:error, %TestException{}}}}
+    assert_received {:record_error, {"path#GET", {:error, %TestException{}}}}
   end
 
-  test "Includes path data in report" do
+  test "Includes request data in report" do
     conn = conn(:get, "/some_path")
 
     catch_error TestPlug.call(conn, [])
-    assert_received {:record_error, {path, {:error, %TestException{}}}}
+    assert_received {:record_error, {transaction, {:error, %TestException{}}}}
 
-    assert path == "/some_path"
+    assert transaction == "some_path#GET"
   end
 end

--- a/test/new_relixir/utils_test.exs
+++ b/test/new_relixir/utils_test.exs
@@ -1,0 +1,31 @@
+defmodule NewRelixir.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias NewRelixir.Utils
+
+  describe "transaction_name/1" do
+    test "uses controller and action name when in Phoenix" do
+      phoenix_conn = %Plug.Conn{
+        private: %{
+          phoenix_action: :index,
+          phoenix_controller: MyApp.ThingsController
+        }
+      }
+
+      assert Utils.transaction_name(phoenix_conn) == "ThingsController#index"
+    end
+
+    test "uses request path and method name when in bare Plug" do
+      plug_conn = %Plug.Conn{
+        request_path: "/the/full/path",
+        method: "GET"
+      }
+
+      assert Utils.transaction_name(plug_conn) == "the/full/path#GET"
+    end
+
+    test "is nil when unable to figure out a transaction name" do
+      assert Utils.transaction_name(%Plug.Conn{}) == nil
+    end
+  end
+end


### PR DESCRIPTION
Errors were previously being tracked with the request path alone, now we apply the same `path#METHOD` format used for regular transactions.