### PR TITLE
Allow nil or an empty list to be passed in to support preload

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -69,6 +69,12 @@ defmodule NewRelixir.Plug.Instrumentation do
     Keyword.put_new(opts, :action, action)
   end
 
+  defp infer_model(nil) do
+    nil
+  end
+  defp infer_model([]) do
+    []
+  end
   defp infer_model(%{__struct__: model_type, __meta__: %Ecto.Schema.Metadata{}}) do
     short_module_name(model_type)
   end


### PR DESCRIPTION
We sometimes pass `nil` or `[]` when we call preload as the first argument. This blows up on instrumentation when it tries to call `Ecto.Queryable.to_query(queryable)` since neither of those are a queryable. 