### PR TITLE
Add @spec definitions

### DIFF
--- a/lib/new_relixir/instrumenters/phoenix.ex
+++ b/lib/new_relixir/instrumenters/phoenix.ex
@@ -15,12 +15,18 @@ defmodule NewRelixir.Instrumenters.Phoenix do
   alias NewRelixir.{CurrentTransaction, Transaction, Utils}
 
   @doc """
-  Start callback for Phoenix controllers. Phoenix calls it once a request is routed,
-  before processing a controller action.
-
+  If first argument is the atom `:start` this is used as the Start callback for
+  Phoenix controllers. Phoenix calls it once a request is routed, before
+  processing a controller action.
   Returns the transaction name, formatted as `Controller#action`. This value is
   stored and passed along as the third argument to the `:stop` callback.
+
+  When called with the atom `:stop` this is used as the Stop callback for
+  Phoenix controllers. Phoenix calls it after the whole controller pipeline
+  finishes executing the routed action. You should additionally provide the
+  elapsed_time and the Transaction as the second and third arguments.
   """
+  @spec phoenix_controller_call(:start, %{}, %Plug.Conn{}) :: transaction :: binary()
   def phoenix_controller_call(:start, _compile_metadata, %{conn: conn}) do
     if NewRelixir.active? do
       transaction = Utils.transaction_name(conn)
@@ -29,10 +35,7 @@ defmodule NewRelixir.Instrumenters.Phoenix do
     end
   end
 
-  @doc """
-  Stop callback for Phoenix controllers. Phonix calls it after the whole controller
-  pipeline finishes executing the routed action.
-  """
+  @spec phoenix_controller_call(:stop, integer(), transaction :: binary()) :: :ok | nil
   def phoenix_controller_call(:stop, elapsed_time, transaction) do
     if NewRelixir.active? do
       elapsed_microseconds = System.convert_time_unit(elapsed_time, :native, :microsecond)


### PR DESCRIPTION
This closes #68 

Only one `@doc` seems to be allowed for functions that have the same name and arity:
https://stackoverflow.com/questions/33046744/documentation-for-functions-with-same-arity

I've combined the two annotations into one `@doc` and added the `@spec` annotations to each function. 
I also made a modification to the description of the :stop callback. Please let me know if any changes should be made.