### PR TITLE
Fix compilation warnings

### DIFF
--- a/lib/new_relixir/plug/instrumentation.ex
+++ b/lib/new_relixir/plug/instrumentation.ex
@@ -20,7 +20,7 @@ defmodule NewRelixir.Plug.Instrumentation do
   can be overriden by providing a `:query` option in `opts`.
   """
   @spec instrument_db(atom, String.t(), [term()], Keyword.t(), fun) :: any
-  def instrument_db(action, sql, params, opts, f) do
+  def instrument_db(_action, sql, _params, opts, f) do
     {elapsed, result} = :timer.tc(f)
 
     opts

--- a/test/new_relixir/plug/exception_test.exs
+++ b/test/new_relixir/plug/exception_test.exs
@@ -11,7 +11,7 @@ defmodule ExceptionTest do
       quote do
         def call(conn, _opts) do
           raise Plug.Conn.WrapperError, conn: conn,
-          kind: :error, stack: System.stacktrace,
+          kind: :error, stack: [],
           reason: TestException.exception([])
         end
       end

--- a/test/new_relixir/plug/repo_test.exs
+++ b/test/new_relixir/plug/repo_test.exs
@@ -27,6 +27,10 @@ defmodule NewRelixir.Plug.RepoTest do
       record_call(:all, [queryable, opts])
     end
 
+    def stream(queryable, opts \\ []) do
+      record_call(:stream, [queryable, opts])
+    end
+
     def get(queryable, id, opts \\ []) do
       record_call(:get, [queryable, id, opts])
     end
@@ -41,6 +45,10 @@ defmodule NewRelixir.Plug.RepoTest do
 
     def get_by!(queryable, clauses, opts \\ []) do
       record_call(:get_by!, [queryable, clauses, opts])
+    end
+
+    def load(schema_or_type, data) do
+      record_call(:load, [schema_or_type, data])
     end
 
     def one(queryable, opts \\ []) do


### PR DESCRIPTION
    warning: variable "action" is unused
      lib/new_relixir/plug/instrumentation.ex:23

    warning: variable "params" is unused
      lib/new_relixir/plug/instrumentation.ex:23

    Generated new_relixir app
    warning: System.stacktrace/0 outside of rescue/catch clauses is deprecated. If you want to support only Elixir v1.7+, you must access __STACKTRACE__ inside a rescue/catch. If you want to support earlier Elixir versions, move System.stacktrace/0 inside a rescue/catch
      test/new_relixir/plug/exception_test.exs:23

    warning: function load/2 required by behaviour Ecto.Repo is not implemented (in module NewRelixir.Plug.RepoTest.FakeRepo)
      test/new_relixir/plug/repo_test.exs:4

    warning: function stream/2 required by behaviour Ecto.Repo is not implemented (in module NewRelixir.Plug.RepoTest.FakeRepo)
      test/new_relixir/plug/repo_test.exs:4