### PR TITLE
Bump the NR version to the latest "supported" version

### DIFF
--- a/lib/new_relixir/agent.ex
+++ b/lib/new_relixir/agent.ex
@@ -42,7 +42,7 @@ defmodule NewRelixir.Agent do
     url = url(collector, [method: :connect])
 
     data = [%{
-      :agent_version => "1.5.0.103",
+      :agent_version => "2.42.0",
       :app_name => [app_name()],
       :host => l2b(hostname),
       :identifier => app_name(),

--- a/lib/new_relixir/agent.ex
+++ b/lib/new_relixir/agent.ex
@@ -2,7 +2,8 @@ defmodule NewRelixir.Agent do
   require Logger
 
   @base_url "http://~s/agent_listener/invoke_raw_method?"
-  @base_args [protocol_version: 10, marshal_format: :json]
+  @base_args [protocol_version: 14, marshal_format: :json]
+  @agent_version "2.56.0.42"
 
   @doc """
   Connects to New Relic and sends the hopefully correctly
@@ -42,7 +43,7 @@ defmodule NewRelixir.Agent do
     url = url(collector, [method: :connect])
 
     data = [%{
-      :agent_version => "2.42.0",
+      :agent_version => @agent_version,
       :app_name => [app_name()],
       :host => l2b(hostname),
       :identifier => app_name(),
@@ -118,7 +119,11 @@ defmodule NewRelixir.Agent do
   end
 
   def request(url, body \\ "[]") do
-    headers = [{"Content-Encoding", "identity"}]
+    headers = [
+      {"Content-Encoding", "identity"},
+      {"User-Agent", "NewRelic-PythonAgent/#{@agent_version} (Python 2.7.10 linux2)"}
+    ]
+
     case :hackney.post(url, headers, body, [:with_body]) do
       {:ok, status, _, body} -> {:ok, status, body}
       error -> error
@@ -140,5 +145,4 @@ defmodule NewRelixir.Agent do
   end
 
   defp url_var({key, value}), do: [to_string(key), "=", to_string(value)]
-
 end


### PR DESCRIPTION
NewRelic recently elected to deprecate old clients, and this pretends to be an older version of the Python Client. As such, come July 29th, it would stop working.

This attempts to bump the version number so as to ensure that it appears to be a "good" client, from NewRelic's perspective.

Pending testing, this PR will also include a bump to the HEX package version